### PR TITLE
Added debounce helper

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -1,1 +1,1 @@
-export { take, takem, put, race, call, apply, cps, fork, spawn, join, cancel, select, actionChannel, cancelled, flush, takeEvery, takeLatest, throttle } from './internal/io'
+export { take, takem, put, race, call, apply, cps, fork, spawn, join, cancel, select, actionChannel, cancelled, flush, debounce, takeEvery, takeLatest, throttle } from './internal/io'

--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -98,12 +98,10 @@ export function channel(buffer = buffers.fixed()) {
     checkForbiddenStates()
     if(!closed) {
       closed = true
-      if(takers.length) {
-        const arr = takers
-        takers = []
-        for (let i = 0, len = arr.length; i < len; i++) {
-          arr[i](END)
-        }
+      const arr = takers
+      takers = []
+      for (let i = 0, len = arr.length; i < len; i++) {
+        arr[i](END)
       }
     }
   }

--- a/src/internal/io.js
+++ b/src/internal/io.js
@@ -1,5 +1,5 @@
 import { sym, is, ident, check, TASK, deprecate } from './utils'
-import { takeEveryHelper, takeLatestHelper, throttleHelper } from './sagaHelpers'
+import { debounceHelper, takeEveryHelper, takeLatestHelper, throttleHelper } from './sagaHelpers'
 
 const IO             = sym('IO')
 const TAKE           = 'TAKE'
@@ -146,6 +146,10 @@ export function cancelled() {
 export function flush(channel) {
   check(channel, is.channel, `flush(channel): argument ${channel} is not valid channel`)
   return effect(FLUSH, channel)
+}
+
+export function debounce(pattern, worker, ...args) {
+  return fork(debounceHelper, pattern, worker, ...args)
 }
 
 export function takeEvery(patternOrChannel, worker, ...args) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -228,7 +228,7 @@ export default function proc(
         result = iterator.throw(arg)
       } else if(arg === TASK_CANCEL) {
         /**
-          getting TASK_CANCEL autoamtically cancels the main task
+          getting TASK_CANCEL automatically cancels the main task
           We can get this value here
 
           - By cancelling the parent task manually


### PR DESCRIPTION
it should be roughly equivalent of:
```javascript
function* debounce(ms, pattern, worker, ...args) {
	let action
	const setAction = ac => action = ac

	while (true) {
		setAction( yield take(pattern) )

		while (true) {
			const { debounced, _action } = yield race({
				debounced: call(delay, ms),
				_action: take(pattern)
			})

			if (debounced) {
				yield fork(worker, ...args, ac)
				break
			}

			setAction(_action)
		}
	}
}
```

In my reasoning this type (forking) of debouncing versus `takeLatest` + `delay` on the beginning is more appropriate for general use cases. As it wont interrupt the asynchronous forked task in the middle which could potentially land the user in some inconsistent state. WDYT?

I see `takeLatest` + `delay` as other useful pattern to use, but the one that shouldnt be labeled as `debounce`.

Also I didnt write tests for it as this one https://github.com/yelouafi/redux-saga/issues/582 should be fixed first, cause `debounce` is ofc time-dependant.

In addition I've tried to simplify helpers creation and moved `END` handling to the `fsmIterator`, but it still stays an open question and the thing to be tested and checked. 