### PR TITLE
Added support for easily making channels out of observables

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "url": "https://github.com/redux-saga/redux-saga/issues"
   },
   "homepage": "https://github.com/redux-saga/redux-saga#readme",
-  "dependencies": {},
+  "dependencies": {
+    "symbol-observable": "^1.0.4"
+  },
   "devDependencies": {
     "babel-cli": "^6.1.18",
     "babel-core": "^6.14.0",
@@ -68,6 +70,7 @@
     "redux": "^3.5.1",
     "redux-logger": "^2.6.1",
     "rimraf": "^2.4.3",
+    "rxjs": "^5.0.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",
     "typescript": "^1.8.10",

--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -1,6 +1,7 @@
 import { is, check, remove, MATCH, internalErr, SAGA_ACTION} from './utils'
 import {buffers} from './buffers'
 import { asap } from './scheduler'
+import $$observable from 'symbol-observable'
 
 const CHANNEL_END_TYPE = '@@redux-saga/CHANNEL_END'
 export const END = {type: CHANNEL_END_TYPE}
@@ -149,6 +150,20 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
       }
     }
   }
+}
+
+export function observableChannel(observable, ...rest) {
+  check(observable, is.observable, 'Invalid observable passed to observableChannel')
+  return eventChannel(emit => {
+    const subscription = observable[$$observable]().subscribe({
+      next: emit,
+      error: emit,
+      complete() {
+        emit(END)
+      }
+    })
+    return () => subscription.unsubscribe()
+  }, ...rest)
 }
 
 export function stdChannel(subscribe) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -408,7 +408,7 @@ export default function proc(
   function runTakeEffect({channel, pattern, maybe}, cb) {
     channel = channel || stdChannel
     const takeCb = inp => (
-        inp instanceof Error  ? cb(inp, true)
+        inp instanceof Error ? cb(inp, true)
       : isEnd(inp) && !maybe ? cb(CHANNEL_END)
       : cb(inp)
     )

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -1,3 +1,5 @@
+import $$observable from 'symbol-observable'
+
 export const sym = id => `@@redux-saga/${id}`
 export const TASK  = sym('TASK')
 export const HELPER  = sym('HELPER')
@@ -28,7 +30,7 @@ export const is = {
   promise   : p => p && is.func(p.then),
   iterator  : it => it && is.func(it.next) && is.func(it.throw),
   task      : t => t && t[TASK],
-  observable: ob => ob && is.func(ob.subscribe),
+  observable: ob => ob && is.func(ob[$$observable]),
   buffer    : buf => buf && is.func(buf.isEmpty) && is.func(buf.take) && is.func(buf.put),
   pattern   : pat => pat && ((typeof pat === 'string') || (typeof pat === 'symbol') || is.func(pat) || is.array(pat)),
   channel   : ch => ch && is.func(ch.take) && is.func(ch.close),


### PR DESCRIPTION
The 'problem' is that simple
```javascript
const chan = observableChannel(Observable.from([1, 2, 3]))
yield take(chan)
```
will result in `END`, as `subscribe` happens first, before taking, but I guess its just the nature of observables and there is not much to do about this without buffering and it is hard to tell upfront what buffers should be used by default.

Ideas:
1. wondering if we could handle yielding observables (maybe wrapping them automatically with `observableChannel`? and then we could treat `call` results the same same when observable
2. also maybe we could implement `$$observable` on the middleware so `put` actions can be observed?