### PR TITLE
Expose onError in runSaga

### DIFF
--- a/src/internal/runSaga.js
+++ b/src/internal/runSaga.js
@@ -8,7 +8,8 @@ export function runSaga(
     dispatch,
     getState,
     sagaMonitor,
-    logger
+    logger,
+    onError
   }
 ) {
 
@@ -24,7 +25,7 @@ export function runSaga(
     subscribe,
     dispatch,
     getState,
-    {sagaMonitor, logger},
+    {sagaMonitor, logger, onError},
     effectId,
     iterator.name
   )


### PR DESCRIPTION
This allows `onError` to be used when using redux-saga outside of react.