### PR TITLE
Update type definitions for recursive SagaIterator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,8 @@ import {Task, Buffer, Channel, Predicate} from "./types";
 
 export {Effect, Pattern, Task, Buffer, Channel, Predicate};
 
-export type SagaIterator = IterableIterator<Effect|Effect[]>;
+type SagaIteratorReturns = Effect | Effect[] | SagaIterator | SagaIterator[];
+export interface SagaIterator extends IterableIterator<SagaIteratorReturns> {}
 
 type Saga0 = () => SagaIterator;
 type Saga1<T1> = (arg1: T1) => SagaIterator;


### PR DESCRIPTION
Previously, the following code would not work:

```const rootSaga = function* () { yield takeLatest(...) };
createSagaMiddleware.run(rootSaga);```

This was because `rootSaga` returned a `IterableIterator<SagaIterator>`, which did not match type `SagaIterator`. This change makes `SagaIterator` recursive.

Note that change from type to interface is due to https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540