### PR TITLE
Fixed action type to pattern matching in case type is a Symbol

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -11,7 +11,7 @@ export const TASK_CANCEL = {toString() { return '@@redux-saga/TASK_CANCEL' }}
 
 const matchers = {
   wildcard  : () => kTrue,
-  default   : pattern => input => input.type === (typeof input.type === 'symbol' ? pattern : String(pattern)),
+  default   : pattern => input => input.type === (typeof pattern === 'symbol' ? pattern : String(pattern)),
   array     : patterns => input => patterns.some(p => matcher(p)(input)),
   predicate : predicate => input => predicate(input)
 }

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -11,7 +11,7 @@ export const TASK_CANCEL = {toString() { return '@@redux-saga/TASK_CANCEL' }}
 
 const matchers = {
   wildcard  : () => kTrue,
-  default   : pattern => input => input.type === String(pattern),
+  default   : pattern => input => input.type === (typeof input.type === 'symbol' ? pattern : String(pattern)),
   array     : patterns => input => patterns.some(p => matcher(p)(input)),
   predicate : predicate => input => predicate(input)
 }


### PR DESCRIPTION
Currently the default matcher transforms all patterns into strings, which is a problem in case of a pattern that needs to be matched against a Symbol. This fixes matching of Symbol action types, which are otherwise ignored by the system due to invalid comparison.

See issue #246