### PR TITLE
Added support for self cancellation via yield cancel()

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -28,6 +28,7 @@
   * [`join(...tasks)`](#jointasks)
   * [`cancel(task)`](#canceltask)
   * [`cancel(...tasks)`](#canceltasks)
+  * [`cancel()`](#cancel)
   * [`select(selector, ...args)`](#selectselector-args)
   * [`actionChannel(pattern, [buffer])`](#actionchannelpattern-buffer)
   * [`flush(channel)`](#flushchannel)
@@ -568,6 +569,34 @@ Creates an Effect description that instructs the middleware to cancel previously
 #### Notes
 
 It simply wraps automatically array of tasks in [cancel effects](#canceltask), so it becomes roughly equivalent of `yield tasks.map(t => cancel(t))`.
+
+### `cancel()`
+
+Creates an Effect description that instructs the middleware to cancel a task in which it has been yielded (self cancellation).
+It allows to reuse desctructor-like logic inside a `finally` blocks for both outer (`cancel(task)`) and self (`cancel()`) cancellations.
+
+#### Example
+
+```javascript
+function* deleteRecord({ payload }) {
+  try {
+    const { confirm, deny } = yield call(prompt);
+    if (confirm) {
+      yield put(actions.deleteRecord.confirmed())
+    }
+    if (deny) {
+      yield cancel()
+    }
+  } catch(e) {
+    // handle failure
+  } finally {
+    if (yield cancelled()) {
+      // shared cancellation logic
+      yield put(actions.deleteRecord.cancel(payload))
+    }
+  }
+}
+```
 
 ### `select(selector, ...args)`
 

--- a/src/internal/io.js
+++ b/src/internal/io.js
@@ -1,4 +1,4 @@
-import { sym, is, ident, check, deprecate } from './utils'
+import { sym, is, ident, check, deprecate, SELF_CANCELLATION } from './utils'
 import { takeEveryHelper, takeLatestHelper, throttleHelper } from './sagaHelpers'
 
 const IO             = sym('IO')
@@ -108,24 +108,22 @@ export function join(...tasks) {
   if (tasks.length > 1) {
     return tasks.map(t => join(t))
   }
-  check(tasks, is.notUndef, 'join(task): argument task is undefined')
-  if(!is.task(tasks[0])) {
-    throw new Error(`join(task): argument ${tasks[0]} is not a valid Task object ${ TEST_HINT }`)
-  }
-
-  return effect(JOIN, tasks[0])
+  const task = tasks[0]
+  check(task, is.notUndef, 'join(task): argument task is undefined')
+  check(task, is.task, `join(task): argument ${task} is not a valid Task object ${ TEST_HINT }`)
+  return effect(JOIN, task)
 }
 
 export function cancel(...tasks) {
   if (tasks.length > 1) {
     return tasks.map(t => cancel(t))
   }
-  check(tasks[0], is.notUndef, 'cancel(task): argument task is undefined')
-  if(!is.task(tasks[0])) {
-    throw new Error(`cancel(task): argument ${tasks[0]} is not a valid Task object ${ TEST_HINT }`)
+  const task = tasks[0]
+  if (tasks.length === 1) {
+    check(task, is.notUndef, 'cancel(task): argument task is undefined')
+    check(task, is.task, `cancel(task): argument ${task} is not a valid Task object ${ TEST_HINT }`)
   }
-
-  return effect(CANCEL, tasks[0])
+  return effect(CANCEL, task || SELF_CANCELLATION)
 }
 
 export function select(selector, ...args) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -1,4 +1,4 @@
-import { noop, kTrue, is, log as _log, check, deferred, uid as nextEffectId, remove, TASK, CANCEL, makeIterator, isDev } from './utils'
+import { noop, kTrue, is, log as _log, check, deferred, uid as nextEffectId, remove, TASK, CANCEL, SELF_CANCELLATION, makeIterator, isDev } from './utils'
 import { asap, suspend, flush } from './scheduler'
 import { asEffect } from './io'
 import { stdChannel as _stdChannel, eventChannel, isEnd } from './channel'
@@ -512,9 +512,12 @@ export default function proc(
     }
   }
 
-  function runCancelEffect(task, cb) {
-    if(task.isRunning()) {
-      task.cancel()
+  function runCancelEffect(taskToCancel, cb) {
+    if (taskToCancel === SELF_CANCELLATION) {
+      taskToCancel = task
+    }
+    if(taskToCancel.isRunning()) {
+      taskToCancel.cancel()
     }
     cb()
     // cancel effects are non cancellables

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -4,6 +4,7 @@ export const HELPER  = sym('HELPER')
 export const MATCH = sym('MATCH')
 export const CANCEL = sym('cancelPromise')
 export const SAGA_ACTION = sym('SAGA_ACTION')
+export const SELF_CANCELLATION = sym('SELF_CANCELLATION')
 export const konst = v => () => v
 export const kTrue = konst(true)
 export const kFalse = konst(false)

--- a/test/proc/cancellation.js
+++ b/test/proc/cancellation.js
@@ -806,3 +806,33 @@ test('cancel should be able to cancel multiple tasks', assert => {
     })
     .catch(err => assert.fail(err))
 })
+
+test('cancel should support for self cancellation', assert => {
+  assert.plan(1)
+
+  let actual = []
+
+  function* worker() {
+    try {
+      yield io.cancel()
+    } finally {
+      if (yield io.cancelled()) {
+        actual.push('self cancellation')
+      }
+    }
+  }
+
+  function* genFn() {
+    yield io.fork(worker)
+  }
+
+  const expected = ['self cancellation']
+
+  proc(genFn()).done
+    .then(() => {
+      assert.deepEqual(actual, expected,
+        'it must be possible to trigger self cancellation'
+      )
+    })
+    .catch(err => assert.fail(err))
+})


### PR DESCRIPTION
- [x] docs

In some discussions on reactiflux the idea of smth like `cancel.propagate()` came up, it would propagate through the task tree 1 level up, leaving further cancellation as responsibility for parent's finally block. Didnt think it through yet, just pitching an idea, but on the first look it could have been somehow leveraged for making supervisor tasks.