### PR TITLE
Remove obsolete argument in throttleHelper

### DIFF
--- a/src/internal/sagaHelpers.js
+++ b/src/internal/sagaHelpers.js
@@ -82,7 +82,7 @@ export function throttleHelper(delayLength, pattern, worker, ...args) {
   let action, channel
 
   const yActionChannel = {done: false, value: actionChannel(pattern, buffers.sliding(1))}
-  const yTake = () => ({done: false, value: take(channel, pattern)})
+  const yTake = () => ({done: false, value: take(channel)})
   const yFork = ac => ({done: false, value: fork(worker, ...args, ac)})
   const yDelay = {done: false, value: call(delay, delayLength)}
 


### PR DESCRIPTION
Remove obsolete argument in throttleHelper as per [issue #807](https://github.com/redux-saga/redux-saga/issues/807)