### PR TITLE
Add onError as option to runSaga

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -932,6 +932,8 @@ connect a Saga to external input/output, other than store actions.
   - `sagaMonitor` : [SagaMonitor](#sagamonitor) - see docs for [`createSagaMiddleware(options)`](#createsagamiddlewareoptions)
 
   - `logger` : `Function` - see docs for [`createSagaMiddleware(options)`](#createsagamiddlewareoptions)
+  
+  - `onError`: `Function` - see docs for [`createSagaMiddleware(options)`](#createsagamiddlewareoptions)
 
 #### Notes
 


### PR DESCRIPTION
runSaga actually accepts onError option in the same way as it is done in middleware