### PR TITLE
add test utilitary function cloneableGenerator

### DIFF
--- a/docs/advanced/Testing.md
+++ b/docs/advanced/Testing.md
@@ -1,8 +1,185 @@
-# Examples of Testing Sagas
+# Testing Sagas
 
-**WIP**
+**Effects return plain javascript objects**
 
-See Repository Examples:
+Those objects describe the effect and redux-saga is in charge to execute them.
+
+This makes testing very easy because all you have to do is compare that the object yielded by the saga describe the effect you want.
+ 
+## Basic Example
+
+```javascript
+console.log(put({ type: MY_CRAZY_ACTION }));
+
+/*
+{
+  @@redux-saga/IO': true,
+  PUT: {
+    channel: null,
+    action: {
+      type: 'MY_CRAZY_ACTION'
+    }
+  }
+}
+ */
+```
+
+Testing a saga that wait for a user action and dispatch
+
+```javascript
+const CHOOSE_COLOR = 'CHOOSE_COLOR';
+const CHANGE_UI = 'CHANGE_UI';
+
+const chooseColor = (color) => ({
+  type: CHOOSE_COLOR,
+  payload: {
+    color,
+  },
+});
+
+const changeUI = (color) => ({
+  type: CHANGE_UI,
+  payload: {
+    color,
+  },
+});
+
+
+function* changeColorSaga() {
+  const action = yield take(CHOOSE_COLOR);
+  yield put(changeUI(action.payload.color));
+}
+
+test('change color saga', assert => {
+  const gen = changeColorSaga();
+
+  assert.deepEqual(
+    gen.next().value,
+    take(CHOOSE_COLOR),
+    'it should wait for a user to choose a color'
+  );
+
+  const color = 'red';
+  assert.deepEqual(
+    gen.next(chooseColor(color)).value,
+    put(changeUI(color)),
+    'it should dispatch an action to change the ui'
+  );
+
+  assert.deepEqual(
+    gen.next().done,
+    true,
+    'it should be done'
+  );
+
+  assert.end();
+});
+```
+
+Another great benefit is that your tests are also your doc! They describe everything that should happen.
+
+## Branching Saga 
+
+Sometimes your saga will have different outcomes. To test the different branches without repeating all the steps that lead to it you can use the utility function **cloneableGenerator**
+```javascript
+const CHOOSE_NUMBER = 'CHOOSE_NUMBER';
+const CHANGE_UI = 'CHANGE_UI';
+const DO_STUFF = 'DO_STUFF';
+
+const chooseNumber = (number) => ({
+  type: CHOOSE_NUMBER,
+  payload: {
+    number,
+  },
+});
+
+const changeUI = (color) => ({
+  type: CHANGE_UI,
+  payload: {
+    color,
+  },
+});
+
+const doStuff = () => ({
+  type: DO_STUFF, 
+});
+
+
+function* doStuffThenChangeColor() {
+  yield put(doStuff());
+  yield put(doStuff());
+  const action = yield take(CHOOSE_NUMBER);
+  if (action.payload.number % 2 === 0) {
+    yield put(changeUI('red'));
+  } else {
+    yield put(changeUI('blue'));
+  }
+}
+
+import { put, take } from 'redux-saga/effects';
+import { cloneableGenerator } from 'redux-saga/utils';
+
+test('doStuffThenChangeColor', assert => {
+  const data = {};
+  data.gen = cloneableGenerator(doStuffThenChangeColor)();
+
+  assert.deepEqual(
+    data.gen.next().value,
+    put(doStuff()),
+    'it should do stuff'
+  );
+
+  assert.deepEqual(
+    data.gen.next().value,
+    put(doStuff()),
+    'it should do stuff'
+  );
+
+  assert.deepEqual(
+    data.gen.next().value,
+    take(CHOOSE_NUMBER),
+    'should wait for the user to give a number'
+  );
+
+  assert.test('user choose an even number', a => {
+    // cloning the generator before sending data
+    data.clone = data.gen.clone();
+    a.deepEqual(
+      data.gen.next(chooseNumber(2)).value,
+      put(changeUI('red')),
+      'should change the color to red'
+    );
+
+    a.equal(
+      data.gen.next().done,
+      true,
+      'it should be done'
+    );
+
+    a.end();
+  });
+
+  assert.test('user choose an odd number', a => {
+    a.deepEqual(
+      data.clone.next(chooseNumber(3)).value,
+      put(changeUI('blue')),
+      'should change the color to blue'
+    );
+
+    a.equal(
+      data.clone.next().done,
+      true,
+      'it should be done'
+    );
+
+    a.end();
+  });
+});
+```
+
+See also: [Task cancellation](TaskCancellation.md) for testing fork effects
+
+See also: Repository Examples:
 
 https://github.com/redux-saga/redux-saga/blob/master/examples/counter/test/sagas.js
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -48,6 +48,7 @@
   * [`eventChannel(subscribe, [buffer], matcher)`](#eventchannelsubscribe-buffer-matcher)
   * [`buffers`](#buffers)
   * [`delay(ms, [val])`](#delayms-val)
+  * [`cloneableGenerator(generatorFunc)`](#cloneablegeneratorgeneratorfunc)
 
 # Cheatsheets
 
@@ -1044,6 +1045,101 @@ Provides some common buffers
 ### `delay(ms, [val])`
 
 Returns a Promise that will resolve after `ms` milliseconds with `val`.
+
+### `cloneableGenerator(generatorFunc)`
+
+Takes a generator function (function*) and returns a generator function.
+All generators instanciated from this function will be cloneable.
+For testing purpose only.
+
+#### Example
+
+This is usefull when you want to test different branch of a saga without having to replay the actions that lead to it.
+ 
+```javascript
+
+function* oddOrEven() {
+  // some stuff are done here
+  yield 1;
+  yield 2;
+  yield 3;
+  
+  const userInput = yield 'enter a number';
+  if (userInput % 2 === 0) {
+    yield 'even';
+  } else {
+    yield 'odd'
+  }
+}
+
+test('my oddOrEven saga', assert => {
+  const data = {};
+  data.gen = cloneableGenerator(oddOrEven)();
+ 
+  assert.equal(
+    data.gen.next().value,
+    1,
+    'it should yield 1'
+  );
+  
+  assert.equal(
+    data.gen.next().value,
+    2,
+    'it should yield 2'
+  );
+  
+  assert.equal(
+    data.gen.next().value,
+    3,
+    'it should yield 3'
+  );
+  
+  assert.equal(
+    data.gen.next().value,
+    'enter a number',
+    'it should ask for a number'
+  );
+  
+  assert.test('even number is given', a => {
+    // we make a clone of the generator before giving the number;
+    data.clone = data.gen.clone();
+    
+    a.equal(
+      data.gen.next(2).value,
+      'even',
+      'it should yield "event"'
+    );
+    
+    a.equal(
+      data.gen.next().done,
+      true,
+      'it should be done'
+    );
+    
+    a.end();
+  });
+  
+  assert.test('odd number is given', a => {
+    
+    a.equal(
+      data.clone.next(1).value,
+      'odd',
+      'it should yield "odd"'
+    );
+    
+    a.equal(
+      data.clone.next().done,
+      true,
+      'it should be done'
+    );
+    
+    a.end();
+  });
+  
+  assert.end();
+});
+
+```
 
 ## Cheatsheets
 

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -148,3 +148,21 @@ export function wrapSagaDispatch(dispatch) {
     return dispatch(wrappedAction)
   }
 }
+
+export const cloneableGenerator = (generatorFunc) => (...args) => {
+  const history = [];
+  const gen = generatorFunc(...args);
+  return {
+    next: (arg) => {
+      history.push(arg);
+      return gen.next(arg);
+    },
+    clone: () => {
+      const clonedGen = cloneableGenerator(generatorFunc)(...args);
+      history.forEach((arg) => clonedGen.next(arg));
+      return clonedGen;
+    },
+    return: (value) => gen.return(value),
+    throw: (exception) => gen.throw(exception)
+  };
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,3 @@
-export { TASK, SAGA_ACTION, noop, is, deferred, arrayOfDeffered, createMockTask } from './internal/utils'
+export { TASK, SAGA_ACTION, noop, is, deferred, arrayOfDeffered, createMockTask, cloneableGenerator } from './internal/utils'
 export { asEffect } from './internal/io'
 export { CHANNEL_END } from './internal/proc'

--- a/test/index.js
+++ b/test/index.js
@@ -26,3 +26,4 @@ import './sagaHelpers/takeEvery'
 import './sagaHelpers/takeLatest'
 import './sagaHelpers/throttle'
 import './typescript';
+import './utils/cloneableGenerator';

--- a/test/utils/cloneableGenerator.js
+++ b/test/utils/cloneableGenerator.js
@@ -1,0 +1,108 @@
+import test from 'tape';
+import { cloneableGenerator } from '../../src/internal/utils';
+
+test('it should allow to "clone" the generator', assert => {
+
+  const genFunc = function* (num1, num2) {
+    yield num1 * num2;
+    const num3 = yield;
+    const add = num1 + num2;
+
+    if (num3 > add) {
+      yield num3 - add;
+    } else if (num3 === add) {
+      yield 'you win';
+    } else {
+      yield add - num3;
+    }
+
+  };
+
+  const cloneableGen = cloneableGenerator(genFunc)(2, 3);
+
+  assert.deepEqual(
+    cloneableGen.next(),
+    {
+      value: 6,
+      done: false
+    }
+  );
+
+  assert.deepEqual(
+    cloneableGen.next(),
+    {
+      value: undefined,
+      done: false
+    }
+  );
+
+  const cloneElseIf = cloneableGen.clone();
+  const cloneElse = cloneElseIf.clone();
+
+  assert.deepEqual(
+    cloneableGen.next(13),
+    {
+      value: 8,
+      done: false
+    }
+  );
+
+  assert.deepEqual(
+    cloneableGen.next(),
+    {
+      value: undefined,
+      done: true
+    }
+  );
+
+  assert.deepEqual(
+    cloneElseIf.next(5),
+    {
+      value: 'you win',
+      done: false
+    }
+  );
+  assert.deepEqual(
+    cloneElseIf.next(),
+    {
+      value: undefined,
+      done: true
+    }
+  );
+
+  assert.deepEqual(
+    cloneElse.next(2),
+    {
+      value: 3,
+      done: false
+    }
+  );
+
+  const cloneReturn = cloneElse.clone();
+  const cloneThrow = cloneElse.clone();
+
+  assert.deepEqual(
+    cloneElse.next(),
+    {
+      value: undefined,
+      done: true
+    }
+  );
+
+
+  assert.deepEqual(
+    cloneReturn.return('toto'),
+    {
+      value: 'toto',
+      done: true
+    }
+  );
+
+  assert.throws(
+    () => cloneThrow.throw('throws an exception'),
+    'throws an exception'
+  );
+
+  assert.end();
+});
+


### PR DESCRIPTION
We use redux-saga at work and in order to test some of them I created a util function cloneableGenerator.
It allows you to clone a generator at a certain point of it's execution.

This is usefull when you want to test a saga which can have differents endings.
ex: the user cancels/approves the order, the http response status, etc

You don't have to create a new generator and "replay" all the steps necessary to come to the branching point.
You can just "clone" the generator at a certain step and use the cloned generator to test the other case.
