### PR TITLE
feat: add generator function resolve

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -372,6 +372,7 @@ export default function proc(
         is.promise(effect)                                   ? resolvePromise(effect, currCb)
       : is.helper(effect)                                    ? runForkEffect(wrapHelper(effect), effectId, currCb)
       : is.iterator(effect)                                  ? resolveIterator(effect, effectId, name, currCb)
+      : is.generator(effect)                                 ? resolveIterator(effect(), effectId, name, currCb)
 
       // declarative effects
       : is.array(effect)                                     ? runParallelEffect(effect, effectId, currCb)

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -33,6 +33,10 @@ export const is = {
   array          : Array.isArray,
   promise        : p => p && is.func(p.then),
   iterator       : it => it && is.func(it.next) && is.func(it.throw),
+  generator      : it => it && is.func(it) && (
+                      'GeneratorFunction' === it.constructor.name ||
+                      'GeneratorFunction' === it.constructor.displayName ||
+                      is.iterator(it.prototype)),
   iterable       : it => it && is.func(Symbol) ? is.func(it[Symbol.iterator]) : is.array(it),
   task           : t => t && t[TASK],
   observable     : ob => ob && is.func(ob.subscribe),


### PR DESCRIPTION
I think somebody will write below code:

```js
function* preTask2() {
  // todo
}

function* task1() {
  // ...
  yield takeEvery('*', (action) => {
    // todo
  })
}

function* task2() {
  // ...
  yield preTask2
}

function* rootSaga() {
  // ...
  yield [task1, task2]
  // ...
}

sagaMiddleware.run(rootSaga)
```

but it doesn't work, sometime it's not easy to find this wrong.
I know that we should invoke the generator function to generator iterator or use `call` effect method:

```js
// ...
yield [task1(), task2()]
// or
yield [call(task1), call(task1)]

//...
yield preTask2()
// or
yield call(preTask2)
```

so I hope add **generator function resolve** feature for the `runEffect`.