### PR TITLE
Fixes #875

### DIFF
--- a/docs/advanced/Channels.md
+++ b/docs/advanced/Channels.md
@@ -91,7 +91,6 @@ function countdown(secs) {
         } else {
           // this causes the channel to close
           emitter(END)
-          clearInterval(iv)
         }
       }, 1000);
       // The subscriber must return an unsubscribe function

--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -124,9 +124,15 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   }
 
   const chan = channel(buffer)
+  const close = () => {
+    if(!chan.__closed__) {
+      chan.close()
+      unsubscribe()
+    }
+  }
   const unsubscribe = subscribe(input => {
     if(isEnd(input)) {
-      chan.close()
+      close()
       return
     }
     if(matcher && !matcher(input)) {
@@ -142,12 +148,7 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   return {
     take: chan.take,
     flush: chan.flush,
-    close: () => {
-      if(!chan.__closed__) {
-        chan.close()
-        unsubscribe()
-      }
-    }
+    close,
   }
 }
 

--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -127,7 +127,9 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   const close = () => {
     if(!chan.__closed__) {
       chan.close()
-      unsubscribe()
+      if (unsubscribe) {
+        unsubscribe()
+      }
     }
   }
   const unsubscribe = subscribe(input => {
@@ -140,6 +142,9 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
     }
     chan.put(input)
   })
+  if (chan.__closed__) {
+    unsubscribe()
+  }
 
   if(!is.func(unsubscribe)) {
     throw new Error('in eventChannel: subscribe should return a function to unsubscribe')
@@ -148,7 +153,7 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   return {
     take: chan.take,
     flush: chan.flush,
-    close,
+    close
   }
 }
 

--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -126,10 +126,10 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   const chan = channel(buffer)
   const close = () => {
     if(!chan.__closed__) {
-      chan.close()
       if (unsubscribe) {
         unsubscribe()
       }
+      chan.close()
     }
   }
   const unsubscribe = subscribe(input => {

--- a/test/channel.js
+++ b/test/channel.js
@@ -250,10 +250,8 @@ test('unsubscribe event channel', assert => {
     }
   });
   chan.take(input => {
-    // console.log(input, unsubscribed);
     assert.equal(input, END, 'should emit END event');
-    // assert.ok(unsubscribed, 'eventChannel should call unsubscribe when END event is emitted asynchronously');
-    setTimeout(() => assert.ok(unsubscribed, 'eventChannel should call unsubscribe when END event is emitted asynchronously'), 0);
+    assert.ok(unsubscribed, 'eventChannel should call unsubscribe when END event is emitted asynchronously');
     assert.end();
   });
 });

--- a/test/channel.js
+++ b/test/channel.js
@@ -202,8 +202,24 @@ test('event channel', assert => {
 
   assert.ok(unsubscribeErr, 'eventChannel should throw if subscriber does not return a function to unsubscribe')
 
+  let unsubscribeWasCalled = false;
+  let chan = eventChannel(() => () => {
+    unsubscribeWasCalled = true;
+  });
+  chan.close();
+  assert.equal(unsubscribeWasCalled, true, 'eventChannel should call unsubscribe when channel is closed')
+
+  unsubscribeWasCalled = false;
+  chan = eventChannel((emitter) => {
+    emitter(END);
+    return () => {
+      unsubscribeWasCalled = true;
+    }
+  });
+  assert.equal(unsubscribeWasCalled, true, 'eventChannel should call unsubscribe when END event is emitted');
+
   const em = emitter()
-  let chan = eventChannel(em.subscribe)
+  chan = eventChannel(em.subscribe)
   let actual = []
 
   chan.take((ac) => actual.push(ac))

--- a/test/channel.js
+++ b/test/channel.js
@@ -218,6 +218,24 @@ test('event channel', assert => {
   });
   assert.equal(unsubscribeWasCalled, true, 'eventChannel should call unsubscribe when END event is emitted');
 
+  unsubscribeWasCalled = false;
+  let milliseconds = 2;
+  chan = eventChannel((emitter) => {
+    const interval = setInterval(() => {
+      milliseconds -= 1;
+      if (milliseconds > 0) {
+        emitter(milliseconds);
+      } else {
+        emitter(END);
+      }
+    }, 1);
+    return () => {
+      clearInterval(interval);
+      unsubscribeWasCalled = true;
+    };
+  });
+  setTimeout(() => assert.equal(unsubscribeWasCalled, true, 'complex eventChannel should call unsubscribe when END event is emitted'), 5);
+
   const em = emitter()
   chan = eventChannel(em.subscribe)
   let actual = []


### PR DESCRIPTION
### What the PR does
- extracts `close` function into variable to ensure `unsubscribe` function gets called when `END` event is emitted.
- updates advanced docs for channels to show that unsubscribe function will be called 

#### Note:
- this is my first code PR for redux-saga, I'm not sure the best way to test this? I see the appropriate [test code here](https://github.com/redux-saga/redux-saga/blob/e237a20e6973585c44b5a098a688a4a3c102c033/test/channel.js#L195) but I'm used to using [Sinon](http://sinonjs.org/) to test that a function got called and I don't see that in this repo.
- thanks to @Andarist for the help! 😄 