### PR TITLE
Replace incorrect function call in tutorial

### DIFF
--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -161,7 +161,7 @@ Now we have 2 Sagas, and we need to start them both at once. To do that, we'll a
 // single entry point to start all Sagas at once
 export default function* rootSaga() {
   yield [
-    helloSaga(),
+    incrementAsync(),
     watchIncrementAsync()
   ]
 }


### PR DESCRIPTION
At this point in the tutorial we have updated the `sagas.js` file to fire up both sagas at once in the `rootSaga()` generator, but the yield statement still contained a default `helloSaga()` function from one of the earlier examples. This PR updates the code snippet replacing `helloSaga()` with `incrementAsync()`.