### PR TITLE
Make redux-saga/utils and redux-saga/effects use the right builds

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/effects')

--- a/effects/package.json
+++ b/effects/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "redux-saga/effects",
+  "private": true,
+  "main": "../lib/effects.js",
+  "module": "../es/effects.js",
+  "jsnext:main": "../es/effects.js"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.14.3",
   "description": "Saga middleware for Redux to handle Side Effects",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "scripts": {
     "lint": "eslint src",

--- a/utils.js
+++ b/utils.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/utils')

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "redux-saga/utils",
+  "private": true,
+  "main": "../lib/utils.js",
+  "module": "../es/utils.js",
+  "jsnext:main": "../es/utils.js"
+}


### PR DESCRIPTION
Fixes issue https://github.com/redux-saga/redux-saga/issues/894

It replaces effects.js and utils.js with package.json files that tell node and bundlers where their respective version of the library resides.

It also adds the "module" field in package.json as an alternative to "jsnext:main" (see this for why https://github.com/rollup/rollup/wiki/pkg.module)