### PR TITLE
update createMockTask docs

### DIFF
--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -81,6 +81,8 @@ There is another direction where the cancellation propagates to as well: the joi
 When `fork` is called it starts the task in the background and also returns task object like we have learned previously. When testing this we have to use utility function `createMockTask`. Object returned from this function should be passed to next `next` call after fork test. Mock task can then be passed to `cancel` for example. Here is test for `main` generator which is on top of this page.
 
 ```javascript
+import { createMockTask } from 'redux-saga/lib/utils';
+
 describe('main', () => {
   const generator = main();
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -49,6 +49,8 @@
   * [`buffers`](#buffers)
   * [`delay(ms, [val])`](#delayms-val)
   * [`cloneableGenerator(generatorFunc)`](#cloneablegeneratorgeneratorfunc)
+  * [`createMockTask()`](#createmocktask)
+
 
 # Cheatsheets
 
@@ -1057,7 +1059,7 @@ For testing purpose only.
 #### Example
 
 This is usefull when you want to test different branch of a saga without having to replay the actions that lead to it.
- 
+
 ```javascript
 
 function* oddOrEven() {
@@ -1065,7 +1067,7 @@ function* oddOrEven() {
   yield 1;
   yield 2;
   yield 3;
-  
+
   const userInput = yield 'enter a number';
   if (userInput % 2 === 0) {
     yield 'even';
@@ -1077,71 +1079,77 @@ function* oddOrEven() {
 test('my oddOrEven saga', assert => {
   const data = {};
   data.gen = cloneableGenerator(oddOrEven)();
- 
+
   assert.equal(
     data.gen.next().value,
     1,
     'it should yield 1'
   );
-  
+
   assert.equal(
     data.gen.next().value,
     2,
     'it should yield 2'
   );
-  
+
   assert.equal(
     data.gen.next().value,
     3,
     'it should yield 3'
   );
-  
+
   assert.equal(
     data.gen.next().value,
     'enter a number',
     'it should ask for a number'
   );
-  
+
   assert.test('even number is given', a => {
     // we make a clone of the generator before giving the number;
     data.clone = data.gen.clone();
-    
+
     a.equal(
       data.gen.next(2).value,
       'even',
       'it should yield "event"'
     );
-    
+
     a.equal(
       data.gen.next().done,
       true,
       'it should be done'
     );
-    
+
     a.end();
   });
-  
+
   assert.test('odd number is given', a => {
-    
+
     a.equal(
       data.clone.next(1).value,
       'odd',
       'it should yield "odd"'
     );
-    
+
     a.equal(
       data.clone.next().done,
       true,
       'it should be done'
     );
-    
+
     a.end();
   });
-  
+
   assert.end();
 });
 
 ```
+### `createMockTask()`
+
+Returns an object that mocks a task.
+For testing purposes only.
+[See Task Cancellation docs for more information.](/docs/advanced/TaskCancellation.md#testing-generators-with-fork-effect)
+)
 
 ## Cheatsheets
 


### PR DESCRIPTION
should fix #495 

- adds `createMockTask` to API section
- references TaskCancellation by @henrika 
- fixes import catch by @cellog