### PR TITLE
Fix: Under certain conditions scheduler may crash with "Maximum call stack size exceeded" error (pt. 2)

### DIFF
--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -15,12 +15,18 @@ let semaphore = 0
   state).
 **/
 function exec(task) {
-  try {
-    suspend()
-    task()
-  } finally {
-    flush()
-  }
+  do {
+    if (!task) {
+      task = queue.shift();
+    }
+    try {
+      suspend();
+      task();
+    } finally {
+      task = undefined;
+      semaphore--;
+    }
+  } while (!semaphore && queue.length);
 }
 
 /**

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -14,29 +14,25 @@ let semaphore = 0
   and flushed after this task has finished (assuming the scheduler endup in a released
   state).
 **/
-function exec(task) {
-  do {
-    if (!task) {
-      task = queue.shift();
-    }
+function exec() {
+  let task;
+  while (!semaphore && (task = queue.shift()) !== undefined) {
     try {
       suspend();
       task();
     } finally {
-      task = undefined;
       semaphore--;
     }
-  } while (!semaphore && queue.length);
+  }
 }
 
 /**
   Executes or queues a task depending on the state of the scheduler (`suspended` or `released`)
 **/
 export function asap(task) {
+  queue.push(task)
   if(!semaphore) {
-    exec(task)
-  } else {
-    queue.push(task)
+    exec()
   }
 }
 
@@ -54,6 +50,6 @@ export function suspend() {
 export function flush() {
   semaphore--
   if(!semaphore && queue.length) {
-    exec(queue.shift())
+    exec()
   }
 }

--- a/test/proc/put.js
+++ b/test/proc/put.js
@@ -1,7 +1,10 @@
 import test from 'tape';
+import { createStore, applyMiddleware } from 'redux'
 import proc from '../../src/internal/proc'
 import * as io from '../../src/effects'
+import * as utils from '../../src/internal/utils'
 import {emitter, channel} from '../../src/internal/channel'
+import sagaMiddleware from '../../src'
 
 
 test('proc put handling', assert => {
@@ -164,4 +167,32 @@ test('proc nested puts handling', assert => {
     assert.end();
   })
 
+});
+
+test('puts emitted while dispatching saga need not to cause stack overflow', assert => {
+  function* root() {
+    yield io.put({type: 'put a lot of actions'})
+    yield io.call(utils.delay, 0);
+  }
+
+  assert.plan(1);
+  const reducer = (state, action) => action.type
+  const middleware = sagaMiddleware({
+    emitter: emit => action => {
+      for (var i = 0; i < 32768; i++) {
+        emit({type: 'test'});
+      }
+    }
+  })
+  const store = createStore(reducer, applyMiddleware(middleware))
+  const runSaga = (saga) => middleware.run(saga);
+
+  store.subscribe(() => { })
+
+  runSaga(root)
+
+  setTimeout(() => {
+    assert.ok(true, "this saga needs to run without stack overflow");
+    assert.end();
+  })
 });

--- a/test/proc/put.js
+++ b/test/proc/put.js
@@ -185,11 +185,10 @@ test('puts emitted while dispatching saga need not to cause stack overflow', ass
     }
   })
   const store = createStore(reducer, applyMiddleware(middleware))
-  const runSaga = (saga) => middleware.run(saga);
 
   store.subscribe(() => { })
 
-  runSaga(root)
+  middleware.run(root)
 
   setTimeout(() => {
     assert.ok(true, "this saga needs to run without stack overflow");

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -1,4 +1,7 @@
+import test from 'tape'
+
 import { take, put, race } from '../src/effects'
+import { asap, flush, suspend } from '../src/internal/scheduler'
 
 export const runSyncDispatchTest = (assert, store, runSaga) => {
   const actual = []
@@ -37,3 +40,37 @@ export const runSyncDispatchTest = (assert, store, runSaga) => {
     assert.end();
   });
 }
+
+test('scheduler executes all recursively triggered tasks in order', assert => {
+  const actual = []
+  assert.plan(1)
+  asap(() => {
+    actual.push('1')
+    asap(() => {
+      actual.push('2')
+    })
+    asap(() => {
+      actual.push('3')
+    })
+  });
+  assert.deepEqual(actual, ['1', '2', '3'])
+  assert.end();
+})
+
+test('scheduler when suspended queues up and executes all tasks on flush', assert => {
+  const actual = []
+  assert.plan(1)
+  suspend()
+  asap(() => {
+    actual.push('1')
+    asap(() => {
+      actual.push('2')
+    })
+    asap(() => {
+      actual.push('3')
+    })
+  });
+  flush()
+  assert.deepEqual(actual, ['1', '2', '3'])
+  assert.end();
+})


### PR DESCRIPTION
This is a followup/continuation of https://github.com/redux-saga/redux-saga/pull/790 to address https://github.com/redux-saga/redux-saga/issues/888

There is a good description of the issue and discussion in the links above, but the short version is that `exec()` and `flush()` have a recursive relationship as a way of iterating through the scheduler's queue, and that errors out at a certain recursion depth. So the fix is to change things so we loop through the queue in a non-recursive way.