### PR TITLE
Fixes Operator Token for Dark Theme Docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -12,6 +12,11 @@
       "weibo": false,
       "instapaper": false,
       "vk": false
+    },
+    "theme-default": {
+      "styles": {
+        "website": "build/gitbook.css"
+      }
     }
   }
 }

--- a/build/gitbook.css
+++ b/build/gitbook.css
@@ -1,0 +1,3 @@
+.token.operator {
+  background: none;
+}


### PR DESCRIPTION
Fixes #477 

- fixes operator token for dark theme
- based off redux [fix here](https://github.com/reactjs/redux/commit/e1407e36f103b0154c0aaf0af898dc41b6c032dc)

<img width="843" alt="screen shot 2017-04-19 at 19 11 34" src="https://cloud.githubusercontent.com/assets/10538297/25206160/434b1330-2534-11e7-8316-f82e2e209a3a.png">
