### PR TITLE
Fix type definitions for greater type safety.

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -60,7 +60,9 @@ type CallFunc4<T1, T2, T3, T4> = (arg1: T1, arg2: T2, arg3: T3,
                                   arg4: T4) => any;
 type CallFunc5<T1, T2, T3, T4, T5> = (arg1: T1, arg2: T2, arg3: T3,
                                       arg4: T4, arg5: T5) => any;
-type CallFuncRest = (...args: any[]) => any;
+type CallFuncRest<T1,T2,T3,T4,T5> = (arg1: T1, arg2: T2, arg3: T3,
+                                     arg4: T4, arg5: T5,
+                                     ...args: any[]) => any;
 
 type CallEffectArg<F> = F | [any, F] | {context: any, fn: F};
 
@@ -75,7 +77,9 @@ interface CallEffectFactory<R> {
                arg1: T1, arg2: T2, arg3: T3): R;
   <T1, T2, T3, T4>(fn: CallEffectArg<CallFunc4<T1, T2, T3, T4>>,
                    arg1: T1, arg2: T2, arg3: T3, arg4: T4): R;
-  (fn: CallEffectArg<CallFuncRest>, ...args: any[]): R;
+  <T1, T2, T3, T4, T5>(fn: CallEffectArg<CallFuncRest<T1,T2,T3,T4,T5>>,
+        arg1: T1, arg2: T2, arg3: T3, arg4: T4,
+                        arg5: T5, ...args: any[]): R;
 }
 
 
@@ -95,7 +99,7 @@ export function apply<T1, T2, T3>(context: any, fn: CallFunc3<T1, T2, T3>,
 export function apply<T1, T2, T3, T4>(context: any, 
                                       fn: CallFunc4<T1, T2, T3, T4>,
                           args: [T1, T2, T3, T4]): CallEffect;
-export function apply(context: any, fn: CallFuncRest, 
+export function apply<T1, T2, T3, T4, T5>(context: any, fn: CallFuncRest<T1,T2,T3,T4,T5>, 
                       ...args: any[]): CallEffect;
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ type Saga2<T1, T2> = (arg1: T1, arg2: T2) => SagaIterator;
 type Saga3<T1, T2, T3> = (arg1: T1, arg2: T2, arg3: T3) => SagaIterator;
 type Saga4<T1, T2, T3, T4> = (arg1: T1, arg2: T2, arg3: T3,
                               arg4: T4) => SagaIterator;
-type SagaRest = (...args: any[]) => SagaIterator;
+type SagaRest<T1, T2, T3, T4, T5> = (arg1: T1, arg2: T2, arg3: T3, arg4: T4,
+                                     arg5: T5, ...args: any[]) => SagaIterator;
 
 
 export interface Monitor {
@@ -41,7 +42,9 @@ export interface SagaMiddleware extends Middleware {
                   arg1: T1, arg2: T2, arg3: T3): Task;
   run<T1, T2, T3, T4>(saga: Saga4<T1, T2, T3, T4>,
                       arg1: T1, arg2: T2, arg3: T3, arg4: T4): Task;
-  run(saga: SagaRest, ...args: any[]): Task;
+  run<T1, T2, T3, T4, T5>(saga: SagaRest<T1,T2,T3,T4,T5>,
+                          arg1: T1, arg2: T2, arg3: T3, arg4: T4,
+                          arg5: T5, ...args: any[]): Task;
 }
 
 


### PR DESCRIPTION
Hello!

I'm new to redux-saga and trying it for the first time with TypeScript. I hope this PR is helpful, but please let me know if anything should be changed.

It looks like there are a few issues with the type definitions that keep typescript from making good use of the types to detect user errors (or I'm just missing something).

In particular:

* `SagaRest` is compatible with e.g. `Saga1`, such that typescript will fall back on it if the argument to a `Saga1` to `run` does not match, thereby not flagging an error.
* The same goes for `call` – the `...args` case is not mutually exclusive with the prior cases, so typescript will not flag argument type errors.
* Same thing with apply.

This PR addresses the first two cases, but I couldn't figure out a way to resolve `apply`.

Side note about apply: I suspect it can't be fixed. If that is the case, it's a little surprising to see a static type for `apply` in a correct case, without any hint that this will not catch errors statically due to the fallback to the `any[]` case. Perhaps apply should not pretend to type its args and just use any?

## Example

I discovered the issue with my very first exploration of redux saga in Typescript:

```ts
function foo(x:number) : string {
  return null as any;
}

export function* rootSaga() : SagaIterator {
  const x : string = yield call(foo, 3)
}
```

Inspecting the type of `call` to see which type overload was selected, VSCode shows me

```ts
(alias) call<number>(fn: ((arg1: number) => any) | [any, (arg1: number) => any] | {
    context: any;
    fn: (arg1: number) => any;
}, arg1: number): CallEffect (+5 overloads)
import call
```

Great! Just as hoped, it knows that my function takes an argument that my argument is a number. 

I then purposefully introduced a type error, by changing argument from a number, to a string:

```ts
  const x : string = yield call(foo, 'bar')
```

Much to my surprise, this did not introduce a type error! The type inferred for `call` in this case was:

```ts
(alias) call(fn: ((...args: any[]) => any) | [any, (...args: any[]) => any] | {
    context: any;
    fn: (...args: any[]) => any;
}, ...args: any[]): CallEffect (+5 overloads)
import call
```

With the updated definitions in this PR, I get the following type error, as desired:

```
The type argument for type parameter 'T1' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
  Type argument candidate 'number' is not a valid type argument because it is not a supertype of candidate '"3"'.
(alias) call<T1>(fn: ((arg1: T1) => any) | [any, (arg1: T1) => any] | {
    context: any;
```
