### PR TITLE
Add a link on ES6 generators and 2 on redux-saga to ExternalResources

### DIFF
--- a/docs/ExternalResources.md
+++ b/docs/ExternalResources.md
@@ -5,6 +5,7 @@
 - [The Definitive Guide to the JavaScript Generators](http://gajus.com/blog/2/the-definitive-guide-to-the-javascript-generators) by Gajus Kuizinas
 - [The Basics Of ES6 Generators](https://davidwalsh.name/es6-generators) by Kyle Simpson
 - [ES6 generators in depth](http://www.2ality.com/2015/03/es6-generators.html) by Axel Rauschmayer
+- [3 cases where JavaScript generators rock (+ understanding them)](https://goshakkk.name/javascript-generators-understanding-sample-use-cases/) by Gosha Arinich
 
 ### Articles on redux-saga
 
@@ -18,6 +19,8 @@
 - [Async Operations using redux saga](https://medium.com/@andresmijares25/async-operations-using-redux-saga-2ba02ae077b3#.556ey5blj) by Andrés Mijares
 - [Introduction to Redux Saga](https://ohyayanotherblog.ghost.io/redux-saga-clock/) by Matt Granmoe
 - [Vuex meets Redux-saga](https://medium.com/@xanf/vuex-meets-redux-saga-e9c6b46555e#.d4318am40) by Illya Klymov
+- [3 common approaches to side-effects in Redux apps](https://goshakkk.name/redux-side-effect-approaches/) by Gosha Arinich
+- [Lazy registration with Redux and Sagas](https://goshakkk.name/lazy-auth-redux-saga-flow/) by Gosha Arinich
 
 ### Addons
 - [redux-saga-sc](https://www.npmjs.com/package/redux-saga-sc) – Provides sagas to easily dispatch redux actions over SocketCluster websockets


### PR DESCRIPTION
First off, thanks for all the effort that went into redux-saga! It certainly did make my day as a React developer more manageable.

I just realized the three particular posts that I've authored some time ago might be relevant to mention on the External Resources page... which I hope does not come off as blatant self-promotion. I'm not in it for the page views, just want to spread the relevant knowledge, which would have been definitely helpful to me when I was just starting out with sagas.

The post on understanding ES6 generators is my third most visited blog post in the past year. It describes the way I think of ES6 generators as "interpreter—program", and redux-saga fits perfectly in this model.

Then there's one comparing the *approach* redux-saga to other alternatives.

The last one demonstrates how sagas make possible a common UI pattern of lazy registration.

If some of the links — or all of them — don't fit this page, feel free to reject the PR.