### PR TITLE
Enable runSaga to subscribe to a channel

### DIFF
--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -157,14 +157,16 @@ export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
   }
 }
 
-export function stdChannel(subscribe) {
-  const chan = eventChannel(cb => subscribe(input => {
-    if (input[SAGA_ACTION]) {
-      cb(input)
-      return
-    }
-    asap(() => cb(input))
-  }))
+export function stdChannel(subscribeFnOrChannel) {
+  const chan =
+      is.channel(subscribeFnOrChannel) ? subscribeFnOrChannel
+    : eventChannel(cb => subscribeFnOrChannel(input => {
+      if (input[SAGA_ACTION]) {
+        cb(input)
+        return
+      }
+      asap(() => cb(input))
+    }))
 
   return {
     ...chan,


### PR DESCRIPTION
## What this PR does
This allows `runSaga` to be passed a Channel instead of a function as its `subscribe` parameter.

## Motivation
We're using something like this at Datadog where we have our frontend telemetry process running as a separate Saga process apart from our Redux-connected Sagas (both for code separation and ease of reuse in non-Redux code). The channel interface makes it a lot easier to send messages to this process from both other sagas and non-saga code, but we had to write a hack like this to get it to work:
```javascript
let subscribers = new Set();
const subscribe = (callback) => {
        subscribers.add(callback);
        return () => subscribers.delete(callback);
};
const telemetryChannel = channel();
const watchChannel = () => telemetryChannel.take(payload => {
        subscribers.forEach(subscriber => subscriber(payload));
        watchChannel();
})();
runSaga(telemetrySaga(), { subscribe })
```

With this PR, we'd be able to just:
```javascript
const telemetryChannel = channel();
runSaga(telemetrySaga(), { subscribe: telemetryChannel });
```

I elected not to modify the `dispatch` property in this PR, because it's easy to just pass `{ dispatch: myChannel.put }`.

## Alternatives
Is overloading `subscribe` a good idea for this behavior? Or, should `runSaga` take a `channel` property instead? 

My concern with that approach would be for a case where you want to subscribe to one channel but dispatch to something else — passing `runSaga(mySaga(), { channel: myChannel })` seems to imply both `take`ing and `put`ting to that channel.