### PR TITLE
Removed Log for Manual Cancel

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -279,12 +279,12 @@ export default function proc(
     iterator._isRunning = false
     stdChannel.close()
     if(!isErr) {
-      if(process.env.NODE_ENV === 'development' && result === TASK_CANCEL) {
-        log('info', `${name} has been cancelled`, '')
-      }
       iterator._result = result
       iterator._deferredEnd && iterator._deferredEnd.resolve(result)
     } else {
+      if(process.env.NODE_ENV === 'development' && result === TASK_CANCEL) {
+        log('info', `${name} has been cancelled`, '')
+      }
       if(result instanceof Error) {
         result.sagaStack = `at ${name} \n ${result.sagaStack || result.stack}`
       }


### PR DESCRIPTION
- Starts #614 

Spec:
- if it's user induced via cancel effect -> no logging should take place
- is it cancel caused by cancel propagation when something throws -> logging should take place in dev mode

Question:
- what I'm not sure is if moving the log statement to the `else` statement where `isErr` is true accomplishes the second bullet point for the "Spec". thoughts @Andarist ?