### PR TITLE
[examples] Change way to get object values to flexible

### DIFF
--- a/examples/real-world/actions/index.js
+++ b/examples/real-world/actions/index.js
@@ -29,27 +29,27 @@ function action(type, payload = {}) {
 }
 
 export const user = {
-  request: login => action(USER.REQUEST, {login}),
-  success: (login, response) => action(USER.SUCCESS, {login, response}),
-  failure: (login, error) => action(USER.FAILURE, {login, error}),
+  request: login => action(USER[REQUEST], {login}),
+  success: (login, response) => action(USER[SUCCESS], {login, response}),
+  failure: (login, error) => action(USER[FAILURE], {login, error}),
 }
 
 export const repo = {
-  request: fullName => action(REPO.REQUEST, {fullName}),
-  success: (fullName, response) => action(REPO.SUCCESS, {fullName, response}),
-  failure: (fullName, error) => action(REPO.FAILURE, {fullName, error}),
+  request: fullName => action(REPO[REQUEST], {fullName}),
+  success: (fullName, response) => action(REPO[SUCCESS], {fullName, response}),
+  failure: (fullName, error) => action(REPO[FAILURE], {fullName, error}),
 }
 
 export const starred = {
-  request: login => action(STARRED.REQUEST, {login}),
-  success: (login, response) => action(STARRED.SUCCESS, {login, response}),
-  failure: (login, error) => action(STARRED.FAILURE, {login, error}),
+  request: login => action(STARRED[REQUEST], {login}),
+  success: (login, response) => action(STARRED[SUCCESS], {login, response}),
+  failure: (login, error) => action(STARRED[FAILURE], {login, error}),
 }
 
 export const stargazers = {
-  request: fullName => action(STARGAZERS.REQUEST, {fullName}),
-  success: (fullName, response) => action(STARGAZERS.SUCCESS, {fullName, response}),
-  failure: (fullName, error) => action(STARGAZERS.FAILURE, {fullName, error}),
+  request: fullName => action(STARGAZERS[REQUEST], {fullName}),
+  success: (fullName, response) => action(STARGAZERS[SUCCESS], {fullName, response}),
+  failure: (fullName, error) => action(STARGAZERS[FAILURE], {fullName, error}),
 }
 
 export const updateRouterState = state => action(UPDATE_ROUTER_STATE, {state})


### PR DESCRIPTION
If we want to change the name of action prefix such as `REQUEST`, `SUCCESS`, `FAILURE`.

We should change lines like:

```js
- const REQUEST = 'REQUEST'
+ const REQUEST = 'ANOTHER_REQUEST' 

export const user = {
  // We have to change ---------- this
  // -------------------------- 👇🏻
   - request: login => action(USER.REQUEST, {login}) 
   + request: login => action(USER.ANOTHER_REQUEST, {login}) 
}
```

But there is a easy way, `[]` notation that doesn't need to change all getters:
```js
- const REQUEST = 'REQUEST'
+ const REQUEST = 'ANOTHER_REQUEST' 

export const user = {
  // We don't have to change.
   request: login => action(USER[REQUEST], {login})
}
```



