### PR TITLE
fixing issue on transpilation (more than one array symbol in proc.js)

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -1,4 +1,4 @@
-import { noop, kTrue, is, log as _log, check, deferred, uid as nextEffectId, array, remove, object, TASK, CANCEL, SELF_CANCELLATION, makeIterator, createSetContextWarning, deprecate, updateIncentive } from './utils'
+import { noop, kTrue, is, log as _log, check, deferred, uid as nextEffectId, array as arrayLib, remove, object, TASK, CANCEL, SELF_CANCELLATION, makeIterator, createSetContextWarning, deprecate, updateIncentive } from './utils'
 import { asap, suspend, flush } from './scheduler'
 import { asEffect } from './io'
 import { stdChannel as _stdChannel, eventChannel, isEnd } from './channel'
@@ -556,7 +556,7 @@ export default function proc(
     function checkEffectEnd() {
       if(completedCount === keys.length) {
         completed = true
-        cb(is.array(effects) ? array.from({ ...results, length: keys.length }) : results)
+        cb(is.array(effects) ? arrayLib.from({ ...results, length: keys.length }) : results)
       }
     }
 


### PR DESCRIPTION
Importing module from es/index.js I get this error:
```
ERROR in ./~/redux-saga/es/internal/proc.js
Module parse failed: /home/sithmel/src/supply/app-timesheet/node_modules/redux-saga/es/internal/proc.js Identifier 'array' has already been declared (35:18)
You may need an appropriate loader to handle this file type.
|     };
|   },
|   array: function array(patterns) {
|     return function (input) {
|       return patterns.some(function (p) {
 @ ./~/redux-saga/es/utils.js 3:0-46
 @ ./~/redux-saga/es/index.js
 @ ./src/ui/components/index.jsx
 @ ./src/ui/index.js
``` 
When I opened the file I noticed the transpiler added a function named array to the file:
```
var matchers = {
  ...
  array: function array(patterns) {
```
and it conflicts with the import:
```
import { noop, ...  array ...  } from './utils';
```
