### PR TITLE
Docs: fix typo

### DIFF
--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -160,9 +160,9 @@ Now we have 2 Sagas, and we need to start them both at once. To do that, we'll a
 ```javascript
 // single entry point to start all Sagas at once
 export default function* rootSaga() {
-  yield all([
-    helloSaga(),
-    watchIncrementAsync()
+  yield call([
+    helloSaga,
+    watchIncrementAsync
   ])
 }
 ```


### PR DESCRIPTION
Found a typo in sagas.js:
- all is not a function but call is
- parentheses of the saga-functions in the array are removed 