### PR TITLE
Now automatically handle jqXHR

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -572,6 +572,8 @@ function* mySaga() {
 }
 ```
 
+redux-saga will automatically cancel jqXHR objects using their `abort` method.
+
 ### `cancel(...tasks)`
 
 Creates an Effect description that instructs the middleware to cancel previously forked tasks.

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -403,6 +403,13 @@ export default function proc(
     const cancelPromise = promise[CANCEL]
     if(typeof cancelPromise === 'function') {
       cb.cancel = cancelPromise
+    } else {
+      // Support jqXHR
+      if(typeof promise.abort === 'function') {
+        cb.cancel = () => promise.abort()
+      }
+      // TODO: add support for the fetch API, whenever they get around to
+      // adding cancel support
     }
     promise.then(
       cb,

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -403,11 +403,8 @@ export default function proc(
     const cancelPromise = promise[CANCEL]
     if(typeof cancelPromise === 'function') {
       cb.cancel = cancelPromise
-    } else {
-      // Support jqXHR
-      if(typeof promise.abort === 'function') {
-        cb.cancel = () => promise.abort()
-      }
+    } else if(typeof promise.abort === 'function')  {
+      cb.cancel = () => promise.abort()
       // TODO: add support for the fetch API, whenever they get around to
       // adding cancel support
     }


### PR DESCRIPTION
Jquery is popular and standard enough that it's probably worth automatically supporting cancellation on `jqXHR` instances, which are the Promise type used for most jq async operations. This patch simply makes it so that, in addition to checking for `promise[CANCEL]`, the promise handler also checks for `promise.abort`, and sets up a cancellation handler if that function exists.