### PR TITLE
Make the test pass in "Basic Concepts: Dispatching actions "

### DIFF
--- a/docs/basics/DispatchingActions.md
+++ b/docs/basics/DispatchingActions.md
@@ -54,7 +54,7 @@ assert.deepEqual(
 )
 
 // create a fake response
-const products = {}
+const products = undefined
 
 // expects a dispatch instruction
 assert.deepEqual(


### PR DESCRIPTION
Hi again (:

I'm new to saga so I could be wrong,
but I believe that the test at the end of [Basic Concepts: Dispatching actions ](https://redux-saga.js.org/docs/basics/DispatchingActions.html)
fails because the fake response needs to be `undefined` instead of `{}`

```js
// ...

// create a fake response
const products = {} // should be undefined ?

// expects a dispatch instruction
assert.deepEqual(
  iterator.next(products).value,
  put({ type: 'PRODUCTS_RECEIVED', products }),
  "fetchProducts should yield an Effect put({ type: 'PRODUCTS_RECEIVED', products })"
)
```

Am I right?
