### PR TITLE
Typings: add optional cancel property on CpsCallback

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -238,7 +238,10 @@ export interface CpsEffect {
   CPS: CallEffectDescriptor;
 }
 
-type CpsCallback = (error: any, result: any) => void;
+type CpsCallback = {
+  (error: any, result: any): void;
+  cancel?(): void;
+};
 
 export function cps(fn: CallEffectFn<Func1<CpsCallback>>): CpsEffect;
 export function cps<T1>(fn: CallEffectFn<Func2<T1, CpsCallback>>,

--- a/test/typescript/effects.ts
+++ b/test/typescript/effects.ts
@@ -209,6 +209,8 @@ function* testCps(): SagaIterator {
 
   yield cps((cb) => {cb(null, 1)});
 
+  yield cps((cb) => {cb.cancel = () => {}});
+
   // typings:expect-error
   yield cps((a: 'a', cb) => {});
   // typings:expect-error


### PR DESCRIPTION
It is possible to write a cancellable CpsEffect by setting the `cancel` property to a function you want to get executed on cancel. Let's update the typings to match the logic in the code.