### PR TITLE
Support non-strict effect combinators in TypeScript

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -84,7 +84,13 @@ export const put: {
 };
 
 
-export type AllEffectDescriptor = Effect[] | {[key: string]: Effect};
+export type GenericAllEffectDescriptor<T> = T[] | {[key: string]: T};
+
+export interface GenericAllEffect<T> {
+  ALL: GenericAllEffectDescriptor<T>;
+}
+
+export type AllEffectDescriptor = GenericAllEffectDescriptor<Effect>;
 
 export interface AllEffect {
   ALL: AllEffectDescriptor;
@@ -93,14 +99,25 @@ export interface AllEffect {
 export function all(effects: Effect[]): AllEffect;
 export function all(effects: {[key: string]: Effect}): AllEffect;
 
+export function all<T>(effects: T[]): GenericAllEffect<T>;
+export function all<T>(effects: {[key: string]: T}): GenericAllEffect<T>;
 
-export type RaceEffectDescriptor = {[key: string]: Effect};
+
+export type GenericRaceEffectDescriptor<T> = {[key: string]: T};
+
+export interface GenericRaceEffect<T> {
+  RACE: GenericRaceEffectDescriptor<T>;
+}
+
+export type RaceEffectDescriptor = GenericRaceEffectDescriptor<Effect>;
 
 export interface RaceEffect {
   RACE: RaceEffectDescriptor;
 }
 
 export function race(effects: {[key: string]: Effect}): RaceEffect;
+
+export function race<T>(effects: {[key: string]: T}): GenericRaceEffect<T>;
 
 
 export interface CallEffectDescriptor {

--- a/test/typescript/effects.ts
+++ b/test/typescript/effects.ts
@@ -846,6 +846,9 @@ function* testDeprecatedParallel(): SagaIterator {
   ];
 }
 
+
+declare const promise: Promise<any>;
+
 function* testAll(): SagaIterator {
   yield all([
     call(() => {}),
@@ -859,6 +862,18 @@ function* testAll(): SagaIterator {
     () => {}
   ]);
 
+  // typings:expect-error
+  yield all([
+    promise,
+  ]);
+
+  // typings:expect-error
+  yield all([
+    1,
+    () => {},
+    promise,
+  ]);
+
   yield all({
     named: call(() => {}),
   });
@@ -866,6 +881,59 @@ function* testAll(): SagaIterator {
   // typings:expect-error
   yield all({
     named: 1,
+  });
+
+  // typings:expect-error
+  yield all({
+    named: () => {},
+  });
+
+  // typings:expect-error
+  yield all({
+    named: promise,
+  });
+
+  // typings:expect-error
+  yield all({
+    named1: 1,
+    named2: () => {},
+    named3: promise,
+  });
+}
+
+function* testNonStrictAll() {
+  yield all([1]);
+
+  yield all([
+    () => {}
+  ]);
+
+  yield all([
+    promise,
+  ]);
+
+  yield all([
+    1,
+    () => {},
+    promise,
+  ]);
+
+  yield all({
+    named: 1,
+  });
+
+  yield all({
+    named: () => {},
+  });
+
+  yield all({
+    named: promise,
+  });
+
+  yield all({
+    named1: 1,
+    named2: () => {},
+    named3: promise,
   });
 }
 
@@ -876,12 +944,44 @@ function* testRace(): SagaIterator {
 
   // typings:expect-error
   yield race({
-    call: 1
+    named: 1,
   });
 
   // typings:expect-error
   yield race({
-    call: () => {}
+    named: () => {},
+  });
+
+  // typings:expect-error
+  yield race({
+    named: promise,
+  });
+
+  // typings:expect-error
+  yield race({
+    named1: 1,
+    named2: () => {},
+    named3: promise,
+  });
+}
+
+function* testNonStrictRace() {
+  yield race({
+    named: 1,
+  });
+
+  yield race({
+    named: () => {},
+  });
+
+  yield race({
+    named: promise,
+  });
+
+  yield race({
+    named1: 1,
+    named2: () => {},
+    named3: promise,
   });
 }
 


### PR DESCRIPTION
Allows including any value to effect combinators `all` and `race`, e. g.:

```ts
function* saga() {
  yield all([
    functionReturningPromise(),  // previously error, now allowed
    // ...
  ])
}
```

To enable strict type-checks, where every combined value must be Effect, annotate generator with `SagaIterator` return type:

```ts
function* saga(): SagaIterator {
  yield all([
    functionReturningPromise(),  // error
    // ...
  ])

  yield all([
    call(functionReturningPromise),  // ok
    // ...
  ])
}
```

Fixes https://github.com/redux-saga/redux-saga/issues/1044.