### PR TITLE
make console.info opt-in

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export { runSaga } from './internal/runSaga'
 export { END, eventChannel, channel } from './internal/channel'
 export { buffers } from './internal/buffers'
 export { takeEvery, takeLatest, throttle } from './internal/sagaHelpers'
-export { delay, CANCEL } from './internal/utils'
+export { delay, CANCEL, logger } from './internal/utils'
 export { detach } from './internal/io'
 
 import * as effects from './effects'

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -140,18 +140,26 @@ export function makeIterator(next, thro = kThrow, name = '', isHelper) {
   return iterator
 }
 
-/**
-  Print error in a useful way whether in a browser environment
-  (with expandable error stack traces), or in a node.js environment
-  (text-only log output)
- **/
-export function log(level, message, error = '') {
+export function logger(level, message, error) {
   /*eslint-disable no-console*/
   if (typeof window === 'undefined') {
     console.log(`redux-saga ${level}: ${message}\n${(error && error.stack) || error}`)
   } else {
     console[level](message, error)
   }
+}
+
+/**
+  Print error in a useful way whether in a browser environment
+  (with expandable error stack traces), or in a node.js environment
+  (text-only log output)
+ **/
+export function log(level, message, error = '') {
+  if (level === 'info') {
+    return;
+  }
+
+  logger(level, message, error);
 }
 
 export function deprecate(fn, deprecationWarning) {


### PR DESCRIPTION
By default all logs with level `info` are disabled.  A user can opt into them by adding a custom logger.

I have also exported the default logger that is currently being using throughout this code so it is an easier interface to opt-in.

```js
import createSagaMiddleware, { logger } from 'redux-saga';

const sagaMiddleware = createSagaMiddleware({ logger });
```

This was me just messing around, I can try to add tests if we feel like this is a decent path.

Relates to #614 #991 #945 