### PR TITLE
Adding actionChannel generator test

### DIFF
--- a/test/channel-recipes.js
+++ b/test/channel-recipes.js
@@ -40,6 +40,26 @@ test('action channel', assert => {
   store.dispatch(END)
 })
 
+test('action channel generator', assert => {
+  assert.plan(2)
+
+  function* saga() {
+    const chan = yield actionChannel('ACTION')
+    while (true) {
+      const { payload } = yield take(chan)
+      yield Promise.resolve() // block
+    }
+  }
+
+  let gen = saga()
+  let chan = actionChannel('ACTION')
+  assert.deepEqual(gen.next().value, chan)
+
+  const mockChannel = channel()
+
+  assert.deepEqual(gen.next(mockChannel).value, take(mockChannel))
+})
+
 test('channel: watcher + max workers', assert => {
   assert.plan(1)
 


### PR DESCRIPTION
Adding the code mentioned in https://github.com/redux-saga/redux-saga/issues/1064#issuecomment-313930462 to make sure that it works, and because I didn't see similar code.  Even though it probably doesn't add any code coverage I think it is a good example to include in the tests, as people using `redux-saga` will and should be able to look at the tests for `redux-saga` in order to learn how they can test their own code.