### PR TITLE
Add type definitions for util's cloneableGenerator function

### DIFF
--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -7,7 +7,8 @@
     "baseUrl": ".",
     "paths": {
       "redux-saga": ["../../index.d.ts"],
-      "redux-saga/effects": ["../../effects.d.ts"]
+      "redux-saga/effects": ["../../effects.d.ts"],
+      "redux-saga/utils": ["../../utils.d.ts"]
     }
   }
 }

--- a/test/typescript/utils.ts
+++ b/test/typescript/utils.ts
@@ -1,0 +1,103 @@
+import {SagaIterator} from 'redux-saga';
+import {put} from 'redux-saga/effects';
+import {cloneableGenerator} from 'redux-saga/utils';
+
+function testCloneableGenerator() {
+  function* testSaga(): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+
+  const cloneableGen = cloneableGenerator(testSaga)();
+  const value = cloneableGen.next().value;
+
+  const clone = cloneableGen.clone();
+  const cloneVal = clone.next().value;
+}
+
+function testCloneableGenerator1() {
+  function* testSaga(n1: number): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+
+  // typings:expect-error
+  cloneableGenerator(testSaga)();
+
+  // typings:expect-error
+  cloneableGenerator(testSaga)('foo');
+
+  cloneableGenerator(testSaga)(1);
+}
+
+function testCloneableGenerator2() {
+  function* testSaga(n1: number, n2: number): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+  cloneableGenerator(testSaga)(1, 2);
+}
+
+function testCloneableGenerator3() {
+  function* testSaga(n1: number, n2: number, n3: number): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+
+  // typings:expect-error
+  cloneableGenerator(testSaga)(1, 2);
+
+  cloneableGenerator(testSaga)(1, 2, 3);
+}
+
+function testCloneableGenerator4() {
+  function* testSaga(
+    n1: number,
+    n2: number,
+    n3: number,
+    n4: number,
+  ): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+  cloneableGenerator(testSaga)(1, 2, 3, 4);
+}
+
+function testCloneableGenerator5() {
+  function* testSaga(
+    n1: number,
+    n2: number,
+    n3: number,
+    n4: number,
+    n5: number,
+  ): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+  cloneableGenerator(testSaga)(1, 2, 3, 4, 5);
+}
+
+function testCloneableGenerator6() {
+  function* testSaga(
+    n1: number,
+    n2: number,
+    n3: number,
+    n4: number,
+    n5: number,
+    n6: number,
+  ): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+  cloneableGenerator(testSaga)(1, 2, 3, 4, 5, 6);
+}
+
+function testCloneableGenerator6Rest() {
+  function* testSaga(
+    n1: number,
+    n2: number,
+    n3: number,
+    n4: number,
+    n5: number,
+    n6: number,
+    n7: number,
+  ): SagaIterator {
+    yield put({type: 'my-action'});
+  }
+  cloneableGenerator(testSaga)(1, 2, 3, 4, 5, 6, 7);
+}
+
+

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -76,3 +76,34 @@ export const asEffect: {
   getContext(effect: Effect): undefined | GetContextEffectDescriptor;
   setContext(effect: Effect): undefined | SetContextEffectDescriptor<any>;
 };
+
+interface SagaIteratorClone extends SagaIterator {
+  clone: () => SagaIteratorClone;
+}
+
+export function cloneableGenerator(
+  iterator: () => SagaIterator
+): () => SagaIteratorClone;
+export function cloneableGenerator<T1>(
+  iterator: (arg1: T1) => SagaIterator
+): (arg1: T1) => SagaIteratorClone;
+export function cloneableGenerator<T1, T2>(
+  iterator: (arg1: T1, arg2: T2) => SagaIterator
+): (arg1: T1, arg2: T2) => SagaIteratorClone;
+export function cloneableGenerator<T1, T2, T3>(
+  iterator: (arg1: T1, arg2: T2, arg3: T3) => SagaIterator
+): (arg1: T1, arg2: T2, arg3: T3) => SagaIteratorClone;
+export function cloneableGenerator<T1, T2, T3, T4>(
+  iterator: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => SagaIterator
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => SagaIteratorClone;
+export function cloneableGenerator<T1, T2, T3, T4, T5>(
+  iterator: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => SagaIterator
+): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => SagaIteratorClone;
+export function cloneableGenerator<T1, T2, T3, T4, T5, T6>(
+  iterator: (arg1: T1, arg2: T2, arg3: T3, 
+             arg4: T4, arg5: T5, arg6: T6,
+             arg7: any, ...rest: any[]) => SagaIterator
+): (arg1: T1, arg2: T2, arg3: T3, 
+    arg4: T4, arg5: T5, arg6: T6,
+    arg7: any, ...rest: any[]
+) => SagaIteratorClone;


### PR DESCRIPTION
This PR adds type definitions for the `cloneableGenerator` function for `react-redux/utils`. It supports up to 6 arguments like the rest of the middleware and helper functions.