### PR TITLE
Make single quotes vs double quotes consistent in the first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class UserComponent extends React.Component {
   ...
   onSomeButtonClicked() {
     const { userId, dispatch } = this.props
-    dispatch({type: 'USER_FETCH_REQUESTED', payload: {userId}})
+    dispatch({type: "USER_FETCH_REQUESTED", payload: {userId}})
   }
   ...
 }

--- a/README_ja.md
+++ b/README_ja.md
@@ -32,7 +32,7 @@ class UserComponent extends React.Component {
   ...
   onSomeButtonClicked() {
     const { userId, dispatch } = this.props
-    dispatch({type: 'USER_FETCH_REQUESTED', payload: {userId}})
+    dispatch({type: "USER_FETCH_REQUESTED", payload: {userId}})
   }
   ...
 }

--- a/README_ru.md
+++ b/README_ru.md
@@ -34,7 +34,7 @@ class UserComponent extends React.Component {
   ...
   onSomeButtonClicked() {
     const { userId, dispatch } = this.props
-    dispatch({type: 'USER_FETCH_REQUESTED', payload: {userId}})
+    dispatch({type: "USER_FETCH_REQUESTED", payload: {userId}})
   }
   ...
 }


### PR DESCRIPTION
My excellent coworker noticed that all of the examples below the first code block use double quotes, but the first dispatch uses single quotes. Was this intentional?