### PR TITLE
Ignore logo for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,5 @@ examples
 
 # doc folders
 docs
+logo
 _book


### PR DESCRIPTION
I don't think it is needed to ship the logos with the npm package, ignore them.