### PR TITLE
Add missing all combinator in cheatsheet

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1193,27 +1193,27 @@ For testing purposes only.
 
 ### Blocking / Non-blocking
 
-| Name                 | Blocking                                               |
-| -------------------- | ------------------------------------------------------ |
-| takeEvery            | No                                                     |
-| takeLatest           | No                                                     |
-| throttle             | No                                                     |
-| take                 | Yes                                                    |
-| take(channel)        | Sometimes (see API reference)                          |
-| take.maybe           | Yes                                                    |
-| put                  | No                                                     |
-| put.resolve          | Yes                                                    |
-| put(channel, action) | No                                                     |
-| call                 | Yes                                                    |
-| apply                | Yes                                                    |
-| cps                  | Yes                                                    |
-| fork                 | No                                                     |
-| spawn                | No                                                     |
-| join                 | Yes                                                    |
-| cancel               | Yes                                                    |
-| select               | No                                                     |
-| actionChannel        | No                                                     |
-| flush                | Yes                                                    |
-| cancelled            | Yes                                                    |
-| race                 | Yes                                                    |
-| [...effects]         | Blocks only if there is a blocking effect in the array |
+| Name                 | Blocking                                                    |
+| -------------------- | ------------------------------------------------------------|
+| takeEvery            | No                                                          |
+| takeLatest           | No                                                          |
+| throttle             | No                                                          |
+| take                 | Yes                                                         |
+| take(channel)        | Sometimes (see API reference)                               |
+| take.maybe           | Yes                                                         |
+| put                  | No                                                          |
+| put.resolve          | Yes                                                         |
+| put(channel, action) | No                                                          |
+| call                 | Yes                                                         |
+| apply                | Yes                                                         |
+| cps                  | Yes                                                         |
+| fork                 | No                                                          |
+| spawn                | No                                                          |
+| join                 | Yes                                                         |
+| cancel               | Yes                                                         |
+| select               | No                                                          |
+| actionChannel        | No                                                          |
+| flush                | Yes                                                         |
+| cancelled            | Yes                                                         |
+| race                 | Yes                                                         |
+| all                  | Blocks if there is a blocking effect in the array or object |


### PR DESCRIPTION
In version 0.15.0 the `all`-effect was added to replace yielding of arrays with effects, which became deprecated. The documenation still includes the array in its cheatsheet at the end of the API-section. This PR exchanges the array with the `all`-effect. As a consequence of the longer text, the whitespace inside the table was adapted to support a visually pleasing formatting.

The attached screenshot shows the changed parts of the cheatsheet:
![redux-saga-pr](https://user-images.githubusercontent.com/12033337/29384757-931edde8-82d5-11e7-8b56-a213dcdd818f.png)
