### PR TITLE
Add typings for `detach`; fix typings tests reporting

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import {Action, Middleware} from "redux";
-import {Effect, Pattern} from "./effects";
+import {Effect, ForkEffect, Pattern} from "./effects";
 
 export {Effect, Pattern};
 
@@ -173,6 +173,7 @@ export const buffers: {
 export function delay(ms: number): Promise<true>;
 export function delay<T>(ms: number, val: T): Promise<T>;
 
+export function detach(forkEffect: ForkEffect): ForkEffect;
 
 import * as effects from './effects';
 import * as utils from './utils';

--- a/test/typescript/effects.ts
+++ b/test/typescript/effects.ts
@@ -1,4 +1,6 @@
-import {SagaIterator, Channel, Task, Buffer, END, buffers} from 'redux-saga'
+import {
+  SagaIterator, Channel, Task, Buffer, END, buffers, detach,
+} from 'redux-saga'
 import {
   take, takem, put, call, apply, cps, fork, spawn,
   join, cancel, select, actionChannel, cancelled, flush,
@@ -465,6 +467,13 @@ function* testCancel(): SagaIterator {
 
   // typings:expect-error
   yield cancel(task, task, {});
+}
+
+function* testDetach(): SagaIterator {
+  yield detach(fork(() => {}));
+
+  // typings:expect-error
+  yield detach(call(() => {}));
 }
 
 function* testSelect(): SagaIterator {

--- a/test/typescript/index.js
+++ b/test/typescript/index.js
@@ -2,6 +2,11 @@ import test from 'tape'
 import { checkDirectory } from 'typings-tester'
 
 test('TypeScript files compile against definitions', assert => {
-  assert.doesNotThrow(() => checkDirectory(__dirname))
+  try {
+    checkDirectory(__dirname)
+  } catch (e) {
+    assert.fail(e);
+  }
+
   assert.end()
 })

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -113,9 +113,6 @@ function testContext() {
   // typings:expect-error
   middleware.setContext({c: 42});
 
-  // typings:expect-error
-  middleware.setContext(42);
-
   middleware.setContext({b: 42});
 
   const task = middleware.run(function* () {yield effect});


### PR DESCRIPTION
* Add typings for `detach` effect transformer (https://github.com/redux-saga/redux-saga/pull/1121)
* Fix typings test failures not being displayed in test output
* Remove failing typings test