### PR TITLE
Fix anchor link to blocking / non-blocking

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -58,7 +58,7 @@
 
 # Cheatsheets
 
-* [Blocking / Non-blocking](#blocking--nonblocking)
+* [Blocking / Non-blocking](#blocking--non-blocking)
 
 ## Middleware API
 


### PR DESCRIPTION
This pull request fixes `blocking / non-blocking` anchor link in API Reference