### PR TITLE
Fixed test in the Task cancellation subchapter

### DIFF
--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -93,7 +93,7 @@ describe('main', () => {
 
   it('forks the service', () => {
     const expectedYield = fork(bgSync);
-    expect(generator.next().value).to.deep.equal(expectedYield);
+    expect(generator.next(true).value).to.deep.equal(expectedYield);
   });
 
   it('waits for stop action and then cancels the service', () => {

--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -93,7 +93,8 @@ describe('main', () => {
 
   it('forks the service', () => {
     const expectedYield = fork(bgSync);
-    expect(generator.next(true).value).to.deep.equal(expectedYield);
+    const mockedAction = { type: 'START_BACKGROUND_SYNC' };
+    expect(generator.next(mockedAction).value).to.deep.equal(expectedYield);
   });
 
   it('waits for stop action and then cancels the service', () => {


### PR DESCRIPTION
There needs to be `true` passed to the generator's next function, otherwise the while loop in the `main `generator gets terminated and the following assertions fail.