### PR TITLE
Fix export error in rootSaga section of tutorial

### DIFF
--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -164,14 +164,25 @@ So to summarize, the `incrementAsync` Saga sleeps for 1 second via the call to `
 
 Next, we created another Saga `watchIncrementAsync`. We use `takeEvery`, a helper function provided by `redux-saga`, to listen for dispatched `INCREMENT_ASYNC` actions and run `incrementAsync` each time.
 
-Now we have 2 Sagas, and we need to start them both at once. To do that, we'll add a `rootSaga` that is responsible for starting our other Sagas. In the same file `sagas.js`, add the following code:
+Now we have 2 Sagas, and we need to start them both at once. To do that, we'll add a `rootSaga` that is responsible for starting our other Sagas. In the same file `sagas.js`, refactor the file as follows:
 
 ```javascript
 import { delay } from 'redux-saga'
 import { put, takeEvery, all } from 'redux-saga/effects'
 
-// ...
 
+function* incrementAsync() {
+  yield delay(1000)
+  yield put({ type: 'INCREMENT' })
+}
+
+
+function* watchIncrementAsync() {
+  yield takeEvery('INCREMENT_ASYNC', incrementAsync)
+}
+
+
+// notice how we now only export the rootSaga
 // single entry point to start all Sagas at once
 export default function* rootSaga() {
   yield all([


### PR DESCRIPTION
The original tutorial shows the `rootSaga` function being exported via `export default`. For beginners, docs don't specify you need to remove the `export` keyword from `incrementAsync` and `watchIncrementAsync` functions in `sagas.js` if you're going to use `export default function* rootSaga()`.  