### PR TITLE
allow thunks in delay value

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -548,4 +548,4 @@ export function throttle<A extends Action, T1, T2, T3, T4, T5, T6>(
   arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6,
   ...rest: any[]): ForkEffect;
 
-  export function delay<T>(ms: number, val?: T): CallEffect;
+export function delay<T>(ms: number, val?: T | (() => T)): CallEffect;

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -98,8 +98,9 @@ export function arrayOfDeferred(length) {
 
 export function delay(ms, val = true) {
   let timeoutId
+  let v = typeof val === 'function' ? val() : val
   const promise = new Promise(resolve => {
-    timeoutId = setTimeout(() => resolve(val), ms)
+    timeoutId = setTimeout(() => resolve(v), ms)
   })
 
   promise[CANCEL] = () => clearTimeout(timeoutId)

--- a/test/typescript/delay.ts
+++ b/test/typescript/delay.ts
@@ -12,4 +12,10 @@ function testDelay() {
     const e: boolean = res;
     const r: string = res;
   });
+
+  delay(1, () => 'foo').then(res => {
+    // typings:expect-error
+    const e: boolean = res;
+    const r: string = res;
+  });
 }

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -12,7 +12,7 @@ import {
 import {Task, Channel, Buffer, SagaIterator} from "./index";
 
 export function delay(ms: number): Promise<true>;
-export function delay<T>(ms: number, val: T): Promise<T>;
+export function delay<T>(ms: number, val: T | (() => T)): Promise<T>;
 
 export const TASK: string | symbol;
 export const SAGA_ACTION: string | symbol;


### PR DESCRIPTION
This commit will simply allow to do:

```js
const session = yield call(delay, 1000, call(fetchApi, '/session'));
```
instead of 
```js
const [session] = yield all([
	call(fetchApi, '/session'),
	call(delay, 1000)
]);
```
(to request the session, with a duration of at least 1000ms (enforce a minimal loading delay))


and can be tested the same way, more easily since `all` returns an array

```js
assert.deepEqual(saga.next().value, call(delay, 1000, call(fetchApi, '/session')));
```
vs
```js
assert.deepEqual(saga.next().value, all([
	call(fetchApi, '/session'),
	call(delay, 1000)
]));
```
