### PR TITLE
remove custom error wrapping

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -167,11 +167,7 @@ export default function proc(
   const logError = err => {
     let message = err.sagaStack
 
-    if (!message && err.stack) {
-      message = err.stack.split('\n')[0].indexOf(err.message) !== -1 ? err.stack : `Error: ${err.message}\n${err.stack}`
-    }
-
-    log('error', `uncaught at ${name}`, message || err.message || err)
+    log('error', message || err)
   }
 
   const taskContext = Object.create(parentContext)


### PR DESCRIPTION
My stack traces with webpack and babel were a lot less useful after adding redux-saga to my application since they never pointed to the webpack bundle instead of the original source files. I removed the error wrapping as discussed in #1240. Getting rid of the error wrapping fixed this for me so maybe it will at least fix that part of @frankandrobot's issue as well.