### PR TITLE
Link to effects list from "Declarative Effects"

### DIFF
--- a/docs/basics/DeclarativeEffects.md
+++ b/docs/basics/DeclarativeEffects.md
@@ -1,6 +1,6 @@
 # Declarative Effects
 
-In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic, we yield plain JavaScript Objects from the Generator. We call those Objects *Effects*. An Effect is simply an object that contains some information to be interpreted by the middleware. You can view Effects like instructions to the middleware to perform some operation (e.g., invoke some asynchronous function, dispatch an action to the store, etc.).
+In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic, we yield plain JavaScript Objects from the Generator. We call those Objects [*Effects*](https://redux-saga.js.org/docs/api/#effect-creators). An Effect is simply an object that contains some information to be interpreted by the middleware. You can view Effects like instructions to the middleware to perform some operation (e.g., invoke some asynchronous function, dispatch an action to the store, etc.).
 
 To create Effects, you use the functions provided by the library in the `redux-saga/effects` package.
 
@@ -129,3 +129,5 @@ assert.deepEqual(iterator.next().value, cps(readFile, '/path/to/file') )
 ```
 
 `cps` also supports the same method invocation form as `call`.
+
+A full list of declarative effects can be found in the [API reference](https://redux-saga.js.org/docs/api/#effect-creators).


### PR DESCRIPTION
While using redux-saga in my own work I've noticed that I Google for
"redux effects" expecting to find a list of the effects that are
available. The first result links to the [Declarative Effects](https://redux-saga.js.org/docs/basics/DeclarativeEffects.html) page
which doesn't contain a list or a link to one. This leads to me racking
my brain to figure out where I saw that list last time.

Adding a link in the first paragraph and another at the bottom of the
page fixes this slight frustration.