### PR TITLE
Move redux to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "url": "https://github.com/redux-saga/redux-saga/issues"
   },
   "homepage": "https://redux-saga.js.org/",
-  "dependencies": {
+  "peerDependencies": {
     "redux": "^3.5.1"
   },
   "devDependencies": {
@@ -105,6 +105,7 @@
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-redux": "^4.4.5",
+    "redux": "^3.5.1",
     "rimraf": "^2.4.3",
     "rollup": "^0.50.0",
     "rollup-plugin-babel": "4.0.0-beta.1",

--- a/src/internal/runSaga.js
+++ b/src/internal/runSaga.js
@@ -1,5 +1,4 @@
-import { compose } from 'redux'
-import { is, check, uid as nextSagaId, wrapSagaDispatch, noop } from './utils'
+import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, compose } from './utils'
 import proc from './proc'
 import { stdChannel } from './channel'
 

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -198,3 +198,15 @@ export const cloneableGenerator = generatorFunc => (...args) => {
     throw: exception => gen.throw(exception),
   }
 }
+
+export const compose = (...funcs) => {
+  if (funcs.length === 0) {
+    return arg => arg
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0]
+  }
+
+  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+}


### PR DESCRIPTION
This PR removes the somewhat unnecessary dependency on `redux` of this library.

`redux-saga` only uses the `compose` method from `redux`, which can be reimplemented in 10 lines of code.

I moved the dependency on `redux` to peerDependencies, because this library was designed as a plugin to redux, and this is the [recommended place](https://nodejs.org/en/blog/npm/peer-dependencies/) to declare such relationships.