### PR TITLE
Safely Handle Various Arguments in Calls to Promise.reject()

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -186,7 +186,7 @@ export default function proc(
 
   const logError = err => {
     log('error', err)
-    if (err.sagaStack) {
+    if (err && err.sagaStack) {
       log('error', err.sagaStack)
     }
   }
@@ -338,11 +338,11 @@ export default function proc(
       })
 
       if (!task.cont) {
-        if (result.sagaStack) {
+        if (result && result.sagaStack) {
           result.sagaStack = sagaStackToString(result.sagaStack)
         }
 
-        if (result instanceof Error && onError) {
+        if (onError) {
           onError(result)
         } else {
           // TODO: could we skip this when _deferredEnd is attached?


### PR DESCRIPTION
Resolves redux-saga/redux-saga#1395

I found the issue with redux-saga/redux-saga#1395, and there are several layers:

1. Rejecting a promise with undefined does actually crash sagas. This is a fairly easy fix.

2. A promise with an unhandled reject() that has an argument other than an Error() object causes that rejection to skip the onError method and just write to the console. This one is a bit more hairy, because the failure is silent in that we can't log it on our end.

The simplest possible solution I can think of is to convert the first argument passed into reject() into an Error() object for promises only... this is a bit dishonest because it's not technically what got passed into reject() but it's not so bad because we're already handling reject() like it's an error anyways

@Andarist Thoughts?