### PR TITLE
Change mainTask.isMainRunning to mainTask.isRunning.

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -311,14 +311,14 @@ export default function proc(
         /**
           This Generator has ended, terminate the main task and notify the fork queue
         **/
-        mainTask.isMainRunning = false
-        mainTask.cont && mainTask.cont(result.value)
+        mainTask.isRunning = false
+        mainTask.cont(result.value)
       }
     } catch (error) {
       if (mainTask.isCancelled) {
         logError(error)
       }
-      mainTask.isMainRunning = false
+      mainTask.isRunning = false
       mainTask.cont(error, true)
     }
   }


### PR DESCRIPTION
From #1399 , after my investigation, I think `mainTask.isMainRunning` should be changed to `mainTask.isRunning` to reflect that task-iterator is closed.

<details>
<summary>
`mainTask.isRunning` tracks whether the task-iterator is closed. It is much like that the chrome inspector shows the iterator status. 
</summary>

![image](https://user-images.githubusercontent.com/5550931/38792266-b38f6b52-417e-11e8-8adc-4eace7586b14.png)
</details>
<br>

I also remove the unnecessary check for `mainTask.cont`. `mainTask.cont` will be set after `mainTask` being passed to `forkQueue`.
