### PR TITLE
babel-plugin: fix relative path calc for babel@6

### DIFF
--- a/packages/babel-plugin-redux-saga/src/index.js
+++ b/packages/babel-plugin-redux-saga/src/index.js
@@ -2,7 +2,7 @@ var SourceMapConsumer = require('source-map').SourceMapConsumer
 var pathFS = require('path')
 
 var globalSymbolName = '@@redux-saga/LOCATION'
-
+var processCwd = process.cwd()
 function getSourceCode (path){
   // use `toString` for babel v7, `getSource` for older versions
   const rawCode = Object.prototype.hasOwnProperty.call(path, 'toString') ? path.toString() : path.getSource();
@@ -13,10 +13,9 @@ function getFilename(fileOptions, useAbsolutePath){
   if(useAbsolutePath){
     return fileOptions.filename
   }
-  if(fileOptions.filenameRelative) {
-    return fileOptions.filenameRelative
-  }
-  return pathFS.relative(fileOptions.cwd, fileOptions.filename)
+  // babel v7 defines cwd. for v6 use fallback
+  const cwd = fileOptions.cwd || processCwd
+  return pathFS.relative(cwd, fileOptions.filename)
 }
 
 function isSaga (path){

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration-es6-modules/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration-es6-modules/babel6-expected.js
@@ -1,7 +1,7 @@
 export function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "declaration-es6-modules/source.js",
+      fileName: "test/fixtures/declaration-es6-modules/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -9,7 +9,7 @@ export function* test1() {
 }
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-es6-modules/source.js",
+    fileName: "test/fixtures/declaration-es6-modules/source.js",
     lineNumber: 1,
     code: null
   }
@@ -19,7 +19,7 @@ export default function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-es6-modules/source.js",
+    fileName: "test/fixtures/declaration-es6-modules/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration-es6-modules/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration-es6-modules/babel7-expected.js
@@ -1,7 +1,7 @@
 export function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "declaration-es6-modules/source.js",
+      fileName: "test/fixtures/declaration-es6-modules/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ export function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-es6-modules/source.js",
+    fileName: "test/fixtures/declaration-es6-modules/source.js",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ export default function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-es6-modules/source.js",
+    fileName: "test/fixtures/declaration-es6-modules/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration-regenerator/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration-regenerator/babel6-expected.js
@@ -13,7 +13,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "declaration-regenerator/source.js",
+              fileName: "test/fixtures/declaration-regenerator/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -29,7 +29,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-regenerator/source.js",
+    fileName: "test/fixtures/declaration-regenerator/source.js",
     lineNumber: 1,
     code: null
   }
@@ -53,7 +53,7 @@ function test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-regenerator/source.js",
+    fileName: "test/fixtures/declaration-regenerator/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration-regenerator/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration-regenerator/babel7-expected.js
@@ -11,7 +11,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "declaration-regenerator/source.js",
+              fileName: "test/fixtures/declaration-regenerator/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -27,7 +27,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-regenerator/source.js",
+    fileName: "test/fixtures/declaration-regenerator/source.js",
     lineNumber: 1,
     code: null
   }
@@ -49,7 +49,7 @@ function test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration-regenerator/source.js",
+    fileName: "test/fixtures/declaration-regenerator/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "declaration/source.js",
+      fileName: "test/fixtures/declaration/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration/source.js",
+    fileName: "test/fixtures/declaration/source.js",
     lineNumber: 1,
     code: null
   }
@@ -22,7 +22,7 @@ function* test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration/source.js",
+    fileName: "test/fixtures/declaration/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/declaration/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/declaration/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "declaration/source.js",
+      fileName: "test/fixtures/declaration/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration/source.js",
+    fileName: "test/fixtures/declaration/source.js",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "declaration/source.js",
+    fileName: "test/fixtures/declaration/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-basic/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-basic/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-basic/source.js",
+      fileName: "test/fixtures/effect-basic/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-basic/source.js",
+    fileName: "test/fixtures/effect-basic/source.js",
     lineNumber: 1,
     code: null
   }
@@ -22,7 +22,7 @@ function* test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-basic/source.js",
+    fileName: "test/fixtures/effect-basic/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-basic/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-basic/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-basic/source.js",
+      fileName: "test/fixtures/effect-basic/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-basic/source.js",
+    fileName: "test/fixtures/effect-basic/source.js",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-basic/source.js",
+    fileName: "test/fixtures/effect-basic/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-delegate/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-delegate/babel6-expected.js
@@ -4,7 +4,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-delegate/source.js",
+    fileName: "test/fixtures/effect-delegate/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-delegate/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-delegate/babel7-expected.js
@@ -3,7 +3,7 @@ function* test1() {
 }
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-delegate/source.js",
+    fileName: "test/fixtures/effect-delegate/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-expression/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-expression/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo.bar(1, 2, 3) || {}, Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-expression/source.js",
+      fileName: "test/fixtures/effect-expression/source.js",
       lineNumber: 2,
       code: "foo.bar(1, 2, 3) || {}"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-expression/source.js",
+    fileName: "test/fixtures/effect-expression/source.js",
     lineNumber: 1,
     code: null
   }
@@ -22,7 +22,7 @@ function* test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-expression/source.js",
+    fileName: "test/fixtures/effect-expression/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-expression/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-expression/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo.bar(1, 2, 3) || {}, Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-expression/source.js",
+      fileName: "test/fixtures/effect-expression/source.js",
       lineNumber: 2,
       code: "foo.bar(1, 2, 3) || {}"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-expression/source.js",
+    fileName: "test/fixtures/effect-expression/source.js",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-expression/source.js",
+    fileName: "test/fixtures/effect-expression/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-method/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-method/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo.bar(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-method/source.js",
+      fileName: "test/fixtures/effect-method/source.js",
       lineNumber: 2,
       code: "foo.bar(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-method/source.js",
+    fileName: "test/fixtures/effect-method/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-method/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-method/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo.bar(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-method/source.js",
+      fileName: "test/fixtures/effect-method/source.js",
       lineNumber: 2,
       code: "foo.bar(1, 2, 3)"
     }
@@ -9,7 +9,7 @@ function* test1() {
 }
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-method/source.js",
+    fileName: "test/fixtures/effect-method/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-nested/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-nested/babel6-expected.js
@@ -2,20 +2,20 @@ function* hasNested() {
   yield Object.defineProperty(call(Object.defineProperty(function* test2() {
     yield Object.defineProperty(call(foo), Symbol.for("@@redux-saga/LOCATION"), {
       value: {
-        fileName: "effect-nested/source.js",
+        fileName: "test/fixtures/effect-nested/source.js",
         lineNumber: 3,
         code: "call(foo)"
       }
     });
   }, Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-nested/source.js",
+      fileName: "test/fixtures/effect-nested/source.js",
       lineNumber: 2,
       code: "function* test2() {\n    yield call(foo)\n  }"
     }
   })), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-nested/source.js",
+      fileName: "test/fixtures/effect-nested/source.js",
       lineNumber: 2,
       code: "call(function* test2() {\n    yield call(foo)\n  })"
     }
@@ -24,7 +24,7 @@ function* hasNested() {
 
 Object.defineProperty(hasNested, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-nested/source.js",
+    fileName: "test/fixtures/effect-nested/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-nested/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-nested/babel7-expected.js
@@ -2,20 +2,20 @@ function* hasNested() {
   yield Object.defineProperty(call(Object.defineProperty(function* test2() {
     yield Object.defineProperty(call(foo), Symbol.for("@@redux-saga/LOCATION"), {
       value: {
-        fileName: "effect-nested/source.js",
+        fileName: "test/fixtures/effect-nested/source.js",
         lineNumber: 3,
         code: "call(foo)"
       }
     });
   }, Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-nested/source.js",
+      fileName: "test/fixtures/effect-nested/source.js",
       lineNumber: 2,
       code: "function* test2() {\n    yield call(foo)\n  }"
     }
   })), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-nested/source.js",
+      fileName: "test/fixtures/effect-nested/source.js",
       lineNumber: 2,
       code: "call(function* test2() {\n    yield call(foo)\n  })"
     }
@@ -23,7 +23,7 @@ function* hasNested() {
 }
 Object.defineProperty(hasNested, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-nested/source.js",
+    fileName: "test/fixtures/effect-nested/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-object-props/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-object-props/babel6-expected.js
@@ -4,7 +4,7 @@ function* withEffectObjectProps() {
     cancelled: take('CANCELLED')
   }), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "effect-object-props/source.js",
+      fileName: "test/fixtures/effect-object-props/source.js",
       lineNumber: 2,
       code: "race({\n    timeout: delay(3000),\n    cancelled: take('CANCELLED'),\n  })"
     }
@@ -13,7 +13,7 @@ function* withEffectObjectProps() {
 
 Object.defineProperty(withEffectObjectProps, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "effect-object-props/source.js",
+    fileName: "test/fixtures/effect-object-props/source.js",
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/effect-object-props/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/effect-object-props/babel7-expected.js
@@ -4,7 +4,7 @@ function* withEffectObjectProps() {
     cancelled: take('CANCELLED')
   }), Symbol.for('@@redux-saga/LOCATION'), {
     value: {
-      fileName: 'effect-object-props/source.js',
+      fileName: 'test/fixtures/effect-object-props/source.js',
       lineNumber: 2,
       code: 'race({\n    timeout: delay(3000),\n    cancelled: take(\'CANCELLED\'),\n  })'
     }
@@ -12,7 +12,7 @@ function* withEffectObjectProps() {
 }
 Object.defineProperty(withEffectObjectProps, Symbol.for('@@redux-saga/LOCATION'), {
   value: {
-    fileName: 'effect-object-props/source.js',
+    fileName: 'test/fixtures/effect-object-props/source.js',
     lineNumber: 1,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/expression/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/expression/babel6-expected.js
@@ -2,7 +2,7 @@ const saga = Object.defineProperty(function* test1() {
   yield 1;
 }, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "expression/source.js",
+    fileName: "test/fixtures/expression/source.js",
     lineNumber: 1,
     code: "function* test1() {\n  yield 1\n}"
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/expression/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/expression/babel7-expected.js
@@ -2,7 +2,7 @@ const saga = Object.defineProperty(function* test1() {
   yield 1;
 }, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "expression/source.js",
+    fileName: "test/fixtures/expression/source.js",
     lineNumber: 1,
     code: "function* test1() {\n  yield 1\n}"
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel6-expected.js
@@ -13,7 +13,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "preset-env/source.js",
+              fileName: "test/fixtures/preset-env/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -29,7 +29,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "preset-env/source.js",
+    fileName: "test/fixtures/preset-env/source.js",
     lineNumber: 1,
     code: null
   }
@@ -53,7 +53,7 @@ function test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "preset-env/source.js",
+    fileName: "test/fixtures/preset-env/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel7-expected.js
@@ -11,7 +11,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "preset-env/source.js",
+              fileName: "test/fixtures/preset-env/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -27,7 +27,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "preset-env/source.js",
+    fileName: "test/fixtures/preset-env/source.js",
     lineNumber: 1,
     code: null
   }
@@ -49,7 +49,7 @@ function test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "preset-env/source.js",
+    fileName: "test/fixtures/preset-env/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/regenerator/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/regenerator/babel6-expected.js
@@ -13,7 +13,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "regenerator/source.js",
+              fileName: "test/fixtures/regenerator/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -29,7 +29,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "regenerator/source.js",
+    fileName: "test/fixtures/regenerator/source.js",
     lineNumber: 1,
     code: null
   }
@@ -53,7 +53,7 @@ function test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "regenerator/source.js",
+    fileName: "test/fixtures/regenerator/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/regenerator/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/regenerator/babel7-expected.js
@@ -11,7 +11,7 @@ function test1() {
           _context.next = 2;
           return Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
             value: {
-              fileName: "regenerator/source.js",
+              fileName: "test/fixtures/regenerator/source.js",
               lineNumber: 2,
               code: "foo(1, 2, 3)"
             }
@@ -27,7 +27,7 @@ function test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "regenerator/source.js",
+    fileName: "test/fixtures/regenerator/source.js",
     lineNumber: 1,
     code: null
   }
@@ -49,7 +49,7 @@ function test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "regenerator/source.js",
+    fileName: "test/fixtures/regenerator/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/typescript/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/typescript/babel6-expected.js
@@ -3,7 +3,7 @@ const sum = (a, b) => a + b;
 function* tstest1() {
   const result = yield Object.defineProperty(sum(1, 2), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "typescript/source.js (source.ts)",
+      fileName: "test/fixtures/typescript/source.js (source.ts)",
       lineNumber: 5,
       code: "sum(1, 2)"
     }
@@ -13,7 +13,7 @@ function* tstest1() {
 
 Object.defineProperty(tstest1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "typescript/source.js (source.ts)",
+    fileName: "test/fixtures/typescript/source.js (source.ts)",
     lineNumber: 4,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/typescript/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/typescript/babel7-expected.js
@@ -2,7 +2,7 @@ const sum = (a, b) => a + b;
 function* tstest1() {
   const result = yield Object.defineProperty(sum(1, 2), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "typescript/source.js (source.ts)",
+      fileName: "test/fixtures/typescript/source.js (source.ts)",
       lineNumber: 5,
       code: "sum(1, 2)"
     }
@@ -11,7 +11,7 @@ function* tstest1() {
 }
 Object.defineProperty(tstest1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "typescript/source.js (source.ts)",
+    fileName: "test/fixtures/typescript/source.js (source.ts)",
     lineNumber: 4,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/use-absolute-path/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/use-absolute-path/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "fixtures/use-absolute-path/source.js",
+      fileName: "{{absolutePath}}",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "fixtures/use-absolute-path/source.js",
+    fileName: "{{absolutePath}}",
     lineNumber: 1,
     code: null
   }
@@ -22,7 +22,7 @@ function* test2() {
 
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "fixtures/use-absolute-path/source.js",
+    fileName: "{{absolutePath}}",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/use-absolute-path/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/use-absolute-path/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), Symbol.for("@@redux-saga/LOCATION"), {
     value: {
-      fileName: "fixtures/use-absolute-path/source.js",
+      fileName: "{{absolutePath}}",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "fixtures/use-absolute-path/source.js",
+    fileName: "{{absolutePath}}",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ function* test2() {
 }
 Object.defineProperty(test2, Symbol.for("@@redux-saga/LOCATION"), {
   value: {
-    fileName: "fixtures/use-absolute-path/source.js",
+    fileName: "{{absolutePath}}",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/use-symbol/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/use-symbol/babel6-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), "@@redux-saga/LOCATION", {
     value: {
-      fileName: "use-symbol/source.js",
+      fileName: "test/fixtures/use-symbol/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, "@@redux-saga/LOCATION", {
   value: {
-    fileName: "use-symbol/source.js",
+    fileName: "test/fixtures/use-symbol/source.js",
     lineNumber: 1,
     code: null
   }
@@ -22,7 +22,7 @@ function* test2() {
 
 Object.defineProperty(test2, "@@redux-saga/LOCATION", {
   value: {
-    fileName: "use-symbol/source.js",
+    fileName: "test/fixtures/use-symbol/source.js",
     lineNumber: 5,
     code: null
   }

--- a/packages/babel-plugin-redux-saga/test/fixtures/use-symbol/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/use-symbol/babel7-expected.js
@@ -1,7 +1,7 @@
 function* test1() {
   yield Object.defineProperty(foo(1, 2, 3), "@@redux-saga/LOCATION", {
     value: {
-      fileName: "use-symbol/source.js",
+      fileName: "test/fixtures/use-symbol/source.js",
       lineNumber: 2,
       code: "foo(1, 2, 3)"
     }
@@ -10,7 +10,7 @@ function* test1() {
 
 Object.defineProperty(test1, "@@redux-saga/LOCATION", {
   value: {
-    fileName: "use-symbol/source.js",
+    fileName: "test/fixtures/use-symbol/source.js",
     lineNumber: 1,
     code: null
   }
@@ -20,7 +20,7 @@ function* test2() {
 }
 Object.defineProperty(test2, "@@redux-saga/LOCATION", {
   value: {
-    fileName: "use-symbol/source.js",
+    fileName: "test/fixtures/use-symbol/source.js",
     lineNumber: 5,
     code: null
   }


### PR DESCRIPTION
there is an incompatibility in options that passed to plugin during processing

**babel v6**
fileOptions.filenameRelative 
.../src/sagas/index.js

fileOptions.cwd
undefined

fileOptions.filename
.../src/sagas/index.js

**babel v7**
fileOptions.filenameRelative 
undefined

fileOptions.cwd
.../src/

fileOptions.filename
.../src/sagas/index.js


so current implementation for getting relative path is not working with babel v6, since relativePath === absolutePatg and cwd is undefined

so I changed logic for `babel@6` to fallback to `process.cwd`
