### PR TITLE
fix npm run bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "integrity": "sha512-PConL+YIK9BgNUWWC2q4fbltj1g475TofpNVNivSypcAAKElfpSS1cv7MrpLYRG8TzZvwcVu9M30hLA/WAp1HQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -57,7 +57,7 @@
         "json5": "0.5.1",
         "lodash": "4.17.5",
         "micromatch": "2.3.11",
-        "resolve": "1.7.0",
+        "resolve": "1.7.1",
         "source-map": "0.5.7"
       },
       "dependencies": {
@@ -354,7 +354,7 @@
       "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -988,12 +988,6 @@
         "through": "2.3.8"
       }
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1085,12 +1079,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -1117,18 +1105,6 @@
       "requires": {
         "color-convert": "1.9.1"
       }
-    },
-    "ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
-      "dev": true
-    },
-    "ansistyles": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-      "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
@@ -1262,12 +1238,6 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1287,12 +1257,6 @@
       "requires": {
         "util": "0.10.3"
       }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1323,37 +1287,10 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "async-some": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
-      "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3"
-      }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
       "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "axios": {
@@ -1404,9 +1341,9 @@
       }
     },
     "babel-eslint": {
-      "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
-      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+      "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.44",
@@ -1631,9 +1568,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "base64url": {
@@ -1648,16 +1585,6 @@
       "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM=",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -1669,15 +1596,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1724,15 +1642,6 @@
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         }
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -1838,7 +1747,7 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000827",
+        "caniuse-lite": "1.0.30000830",
         "electron-to-chromium": "1.3.42"
       }
     },
@@ -1848,7 +1757,7 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
+        "base64-js": "1.3.0",
         "ieee754": "1.1.11",
         "isarray": "1.0.0"
       }
@@ -1875,12 +1784,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true
-    },
-    "builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "bundlesize": {
@@ -1986,21 +1889,15 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000827",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz",
-      "integrity": "sha512-j9Q9hP5AhqOARNP6fLdctr3XrGhF921sBSycudf4E+8RCWpFT3rJdTfp/5o8LDp6p0NJTpYWEpBFiM+QEDzA6g==",
+      "version": "1.0.30000830",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
+      "integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
       "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "center-align": {
@@ -2014,14 +1911,14 @@
       }
     },
     "chalk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "5.3.0"
+        "supports-color": "5.4.0"
       }
     },
     "chardet": {
@@ -2039,6 +1936,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2046,12 +1944,6 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
     },
     "ci-env": {
       "version": "1.1.0",
@@ -2251,15 +2143,6 @@
         "wcwidth": "1.0.1"
       }
     },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
     "command-join": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
@@ -2346,16 +2229,16 @@
       "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.23.tgz",
-      "integrity": "sha512-yCPXU/OXJmxgbvTQfIKXKwKa4KQTvlO0a4T/371Raz3bdxcHIGhQtHtdrNee4Z8nGLNfe54njHDblVG2JNFyjg==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.6.6",
         "conventional-changelog-atom": "0.2.8",
         "conventional-changelog-codemirror": "0.3.8",
-        "conventional-changelog-core": "2.0.10",
-        "conventional-changelog-ember": "0.3.11",
+        "conventional-changelog-core": "2.0.11",
+        "conventional-changelog-ember": "0.3.12",
         "conventional-changelog-eslint": "1.0.9",
         "conventional-changelog-express": "0.3.6",
         "conventional-changelog-jquery": "0.1.0",
@@ -2400,13 +2283,13 @@
       }
     },
     "conventional-changelog-cli": {
-      "version": "1.3.21",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.21.tgz",
-      "integrity": "sha512-K9VBljxzuATZCLTVnI83PN7WdeRJRPPB5FumuLk4ES3E+m2YJvX07DRbdJlINk6C2DeAjj4ioS5JvsvJaaCRbA==",
+      "version": "1.3.22",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
+      "integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
       "dev": true,
       "requires": {
         "add-stream": "1.0.0",
-        "conventional-changelog": "1.1.23",
+        "conventional-changelog": "1.1.24",
         "lodash": "4.17.5",
         "meow": "4.0.0",
         "tempfile": "1.1.1"
@@ -2438,9 +2321,9 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.10.tgz",
-      "integrity": "sha512-FP0NHXIbpvU+f5jk/qZdnodhFmlzKW8ENRHQIWT69oe7ffur9nFRVJZlnXnFBOzwHM9WIRbC15ZWh9HZN6t9Uw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
+      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
       "dev": true,
       "requires": {
         "conventional-changelog-writer": "3.0.9",
@@ -2552,9 +2435,9 @@
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.11.tgz",
-      "integrity": "sha512-ErjPPiDmTd/WPgj2bSp+CGsLtJiv7FbdPKjZXH2Cd5P7j44Rqf0V9SIAAYFTQNoPqmvcp+sIcr/vH52WzPJUbw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
+      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
@@ -2967,7 +2850,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "md5.js": "1.3.4",
-        "ripemd160": "2.0.1",
+        "ripemd160": "2.0.2",
         "sha.js": "2.4.11"
       }
     },
@@ -2980,7 +2863,7 @@
         "cipher-base": "1.0.4",
         "create-hash": "1.2.0",
         "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
+        "ripemd160": "2.0.2",
         "safe-buffer": "5.1.1",
         "sha.js": "2.4.11"
       }
@@ -3016,26 +2899,6 @@
         "which": "1.3.0"
       }
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
-      }
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -3049,7 +2912,7 @@
         "create-hmac": "1.1.7",
         "diffie-hellman": "5.0.3",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
+        "pbkdf2": "3.0.16",
         "public-encrypt": "4.0.2",
         "randombytes": "2.0.6",
         "randomfill": "1.0.4"
@@ -3082,15 +2945,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
@@ -3117,12 +2971,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -3285,12 +3133,6 @@
         }
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3324,16 +3166,6 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
-      }
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3381,16 +3213,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3603,7 +3425,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -3902,12 +3724,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -3948,12 +3764,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -4137,23 +3947,6 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4198,55 +3991,539 @@
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+    "fsevents": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.2.tgz",
+      "integrity": "sha512-iownA+hC4uHFp+7gwP/y5SzaiUo7m2vpa0dhpzw8YuKtiZsz7cIXsFbXpLEeBM6WuCQyw1MH4RRe6XI8GFUctQ==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
-    },
-    "fstream-npm": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.0.7.tgz",
-      "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
-      "dev": true,
-      "requires": {
-        "fstream-ignore": "1.0.5",
-        "inherits": "2.0.3"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.9.1"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
       }
     },
     "function-bind": {
@@ -4503,15 +4780,6 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
     "gh-pages": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.1.0.tgz",
@@ -4715,12 +4983,6 @@
         }
       }
     },
-    "github-url-from-username-repo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -4851,22 +5113,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -4977,18 +5223,6 @@
         "minimalistic-assert": "1.0.1"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "history": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
@@ -5022,12 +5256,6 @@
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.0",
@@ -5072,17 +5300,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": "1.4.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -5157,12 +5374,6 @@
       "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
       "dev": true
     },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -5209,22 +5420,6 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "init-package-json": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.6.tgz",
-      "integrity": "sha1-eJ/Ct0RmpJUrnqd8BXW8eOvWCmE=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "npm-package-arg": "4.1.1",
-        "promzard": "0.3.0",
-        "read": "1.0.7",
-        "read-package-json": "2.0.13",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3",
-        "validate-npm-package-name": "3.0.0"
-      }
-    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -5232,7 +5427,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
@@ -5599,12 +5794,6 @@
         "text-extensions": "1.7.0"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -5648,12 +5837,6 @@
         "whatwg-fetch": "2.0.4"
       }
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -5668,13 +5851,6 @@
         "argparse": "1.0.10",
         "esprima": "4.0.0"
       }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
     },
     "jsesc": {
       "version": "2.5.1",
@@ -5692,12 +5868,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -5745,18 +5915,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5791,17 +5949,17 @@
       }
     },
     "lerna": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.10.1.tgz",
-      "integrity": "sha512-p0Rmew8TEa/4wKDuaOYfTFx1VtNeMqjSJgjUkmIqqIdnFeEMDuL0gTY3JFRjnjfmWT9BEHaObC+orHlgN9orfA==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.10.2.tgz",
+      "integrity": "sha512-JijbAQoVQggw31xOOBXQ9Lvh7W8Obb5dl/4OH2Vv3+VIKFgqOwcxkzCWfNV9pbdiMA1OHAXo55aHe2WBqS2oNw==",
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
         "command-join": "2.0.0",
-        "conventional-changelog-cli": "1.3.21",
+        "conventional-changelog-cli": "1.3.22",
         "conventional-recommended-bump": "1.2.1",
         "dedent": "0.7.0",
         "execa": "0.8.0",
@@ -6027,7 +6185,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.9",
+        "rxjs": "5.5.10",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       },
@@ -6380,24 +6538,6 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
-    },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -6862,9 +7002,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz",
-      "integrity": "sha512-1muXCh8jb1N/gHRbn9VDUBr0GYb8A/aVcHlII9QSB68a50spqEVLIGN6KVmCOnSvJrUhC0edGgKU5ofnGXdYdg==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
       "dev": true
     },
     "ms": {
@@ -6878,6 +7018,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -6977,7 +7124,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.1",
         "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.6",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -6997,15 +7144,6 @@
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -7051,68 +7189,68 @@
         "archy": "1.0.0",
         "async-some": "1.0.2",
         "chownr": "1.0.1",
-        "cmd-shim": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-        "columnify": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-        "config-chain": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.10",
         "debuglog": "1.0.1",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
         "fs-vacuum": "1.2.7",
-        "fs-write-stream-atomic": "1.0.10",
+        "fs-write-stream-atomic": "1.0.8",
         "fstream": "1.0.8",
         "fstream-npm": "1.0.7",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-        "has-unicode": "file:../has-unicode",
-        "hosted-git-info": "2.1.5",
+        "glob": "7.0.0",
+        "graceful-fs": "4.1.3",
+        "has-unicode": "2.0.0",
+        "hosted-git-info": "2.1.4",
         "iferr": "0.1.5",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "imurmurhash": "0.1.4",
         "inflight": "1.0.4",
         "inherits": "2.0.1",
         "ini": "1.3.4",
-        "init-package-json": "1.9.6",
+        "init-package-json": "1.9.3",
         "lockfile": "1.0.1",
         "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.4.0.tgz",
+        "lodash._baseuniq": "4.4.0",
         "lodash._bindcallback": "3.0.1",
         "lodash._cacheindexof": "3.0.2",
         "lodash._createcache": "3.1.2",
         "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.3.0.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.3.tgz",
+        "lodash.clonedeep": "4.3.0",
+        "lodash.isarguments": "3.0.7",
+        "lodash.isarray": "4.0.0",
+        "lodash.keys": "4.0.3",
         "lodash.restparam": "3.6.1",
-        "lodash.union": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.2.0.tgz",
-        "lodash.uniq": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.2.0.tgz",
-        "lodash.without": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.1.0.tgz",
+        "lodash.union": "4.2.0",
+        "lodash.uniq": "4.2.0",
+        "lodash.without": "4.1.0",
         "mkdirp": "0.5.1",
-        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.0.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "node-gyp": "3.3.0",
+        "nopt": "3.0.6",
         "normalize-git-url": "3.0.1",
         "normalize-package-data": "2.3.5",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-package-arg": "4.1.1",
+        "npm-package-arg": "4.1.0",
         "npm-registry-client": "7.0.9",
         "npm-user-validate": "0.1.2",
-        "npmlog": "2.0.4",
-        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+        "npmlog": "2.0.2",
+        "once": "1.3.3",
         "opener": "1.4.1",
         "osenv": "0.1.3",
         "path-is-inside": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
+        "read-package-json": "2.0.3",
         "read-package-tree": "5.1.2",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+        "readable-stream": "2.0.5",
         "readdir-scoped-modules": "1.0.2",
-        "realize-package-specifier": "3.0.3",
-        "request": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-        "retry": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+        "realize-package-specifier": "3.0.1",
+        "request": "2.69.0",
+        "retry": "0.9.0",
+        "rimraf": "2.5.2",
+        "semver": "5.1.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "1.0.0",
@@ -7121,69 +7259,70 @@
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
-        "unique-filename": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+        "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "2.2.2",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+        "which": "1.2.4",
         "wrappy": "1.0.1",
         "write-file-atomic": "1.1.4"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+          "bundled": true,
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.1.tgz",
-          "integrity": "sha1-xKwsxb7PuLCZ3n758CeQ59Mtme8=",
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
+        },
+        "async-some": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3"
+          }
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
-          "version": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+          "version": "2.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "graceful-fs": "4.1.3",
             "mkdirp": "0.5.1"
           }
         },
         "columnify": {
-          "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "version": "1.5.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "3.0.0",
@@ -7192,8 +7331,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "defaults": "1.0.3"
@@ -7201,8 +7339,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "clone": "1.0.2"
@@ -7210,8 +7347,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -7221,8 +7357,8 @@
           }
         },
         "config-chain": {
-          "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-          "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+          "version": "1.1.10",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "1.3.4",
@@ -7231,99 +7367,160 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+          "bundled": true,
           "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.3",
+            "wrappy": "1.0.1"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.7.tgz",
-          "integrity": "sha1-deUB+dKIm6L+n+Evk2ul2tUMo1o=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "graceful-fs": "4.1.3",
             "path-is-inside": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
+            "rimraf": "2.5.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.3",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.0.5"
           }
         },
         "fstream": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "integrity": "sha1-fo16c6uzZH7zbkuKFcqAHboD0Dg=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "graceful-fs": "4.1.3",
             "inherits": "2.0.1",
             "mkdirp": "0.5.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
+            "rimraf": "2.5.2"
           }
         },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+        "fstream-npm": {
+          "version": "1.0.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "file:../has-unicode",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "fstream-ignore": "1.0.3",
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "fstream-ignore": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fstream": "1.0.8",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-          "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
+          "version": "7.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "1.0.4",
             "inherits": "2.0.1",
             "minimatch": "3.0.0",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "path-is-absolute": "1.0.0"
           },
           "dependencies": {
             "minimatch": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
+                "brace-expansion": "1.1.3"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
+                  "version": "1.1.3",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                    "balanced-match": "0.3.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                      "version": "0.3.0",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -7332,116 +7529,174 @@
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-          "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw=",
+          "version": "4.1.3",
+          "bundled": true,
           "dev": true
         },
         "has-unicode": {
-          "version": "file:../has-unicode",
-          "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+          "version": "2.1.4",
+          "bundled": true,
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+            "once": "1.3.3",
             "wrappy": "1.0.1"
           }
         },
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+        "init-package-json": {
+          "version": "1.9.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "6.0.4",
+            "npm-package-arg": "4.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.3",
+            "semver": "5.1.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "2.2.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.3"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "read": "1.0.7"
+              }
+            }
+          }
         },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseuniq": {
-          "version": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.4.0.tgz",
-          "integrity": "sha1-pEUpQ0ei9TEfWF/jIlZEUwubj64=",
+          "version": "4.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "lodash._setcache": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.0.tgz"
+            "lodash._root": "3.0.1",
+            "lodash._setcache": "4.1.0"
           },
           "dependencies": {
             "lodash._root": {
-              "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+              "version": "3.0.1",
+              "bundled": true,
               "dev": true
             },
             "lodash._setcache": {
-              "version": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.0.tgz",
-              "integrity": "sha1-7MSHGTRvr2ZzQ7OQtFcqMGPzgnw=",
+              "version": "4.1.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+          "bundled": true,
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+          "bundled": true,
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
@@ -7449,111 +7704,108 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "bundled": true,
           "dev": true
         },
         "lodash.clonedeep": {
-          "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.3.0.tgz",
-          "integrity": "sha1-1gIzAcGUREW3AlctNMSzTCtyZnU=",
+          "version": "4.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseclone": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.0.tgz"
+            "lodash._baseclone": "4.5.0"
           },
           "dependencies": {
             "lodash._baseclone": {
-              "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.0.tgz",
-              "integrity": "sha1-cVEVZJBhGk9sJhZKS+SYZtpoOyw=",
+              "version": "4.5.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash.isarguments": {
-          "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
-          "integrity": "sha1-8LkWnPQSwR2KR5ziHgb+EUVBdJU=",
+          "version": "3.0.7",
+          "bundled": true,
           "dev": true
         },
         "lodash.isarray": {
-          "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-          "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "lodash.keys": {
-          "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.3.tgz",
-          "integrity": "sha1-9pi7de365vaQ254RkIFXcy/ns0I=",
+          "version": "4.0.3",
+          "bundled": true,
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "bundled": true,
           "dev": true
         },
         "lodash.union": {
-          "version": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.2.0.tgz",
-          "integrity": "sha1-SQyGgD0u18oB4m/lPn1lGeJQZQU=",
+          "version": "4.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseflatten": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-4.1.0.tgz",
-            "lodash._baseuniq": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.4.0.tgz",
-            "lodash.rest": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
+            "lodash._baseflatten": "4.1.0",
+            "lodash._baseuniq": "4.4.0",
+            "lodash.rest": "4.0.1"
           },
           "dependencies": {
             "lodash._baseflatten": {
-              "version": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-4.1.0.tgz",
-              "integrity": "sha1-hUisR1dqjdXycCyx6+rkqYCsO64=",
+              "version": "4.1.0",
+              "bundled": true,
               "dev": true
             },
             "lodash.rest": {
-              "version": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz",
-              "integrity": "sha1-y+y7hOaOSZobJCuvmye7Y+9N2YA=",
+              "version": "4.0.1",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash.uniq": {
-          "version": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.2.0.tgz",
-          "integrity": "sha1-4MsqxX4RtqDQyHZ09v9KGYb3hzk=",
+          "version": "4.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseuniq": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.4.0.tgz"
+            "lodash._baseuniq": "4.4.0"
           }
         },
         "lodash.without": {
-          "version": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.1.0.tgz",
-          "integrity": "sha1-Kd9N2CDUDREWwmGxQHioGoBN0iE=",
+          "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._basedifference": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.4.0.tgz",
-            "lodash.rest": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
+            "lodash._basedifference": "4.4.0",
+            "lodash.rest": "4.0.1"
           },
           "dependencies": {
             "lodash._basedifference": {
-              "version": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.4.0.tgz",
-              "integrity": "sha1-sMNk7NMZx2aQktwfhMRm95hkK+M=",
+              "version": "4.4.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._setcache": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.0.tgz"
+                "lodash._setcache": "4.1.0"
               },
               "dependencies": {
                 "lodash._setcache": {
-                  "version": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.0.tgz",
-                  "integrity": "sha1-7MSHGTRvr2ZzQ7OQtFcqMGPzgnw=",
+                  "version": "4.1.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "lodash.rest": {
-              "version": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz",
-              "integrity": "sha1-y+y7hOaOSZobJCuvmye7Y+9N2YA=",
+              "version": "4.0.1",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7561,71 +7813,68 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "node-gyp": {
-          "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.0.tgz",
-          "integrity": "sha1-fMZ2ty0L4x3Jd/s8k1Ocq3re/x4=",
+          "version": "3.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream": "1.0.8",
             "glob": "4.5.3",
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+            "graceful-fs": "4.1.3",
+            "minimatch": "1.0.0",
             "mkdirp": "0.5.1",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "npmlog": "2.0.4",
+            "nopt": "3.0.6",
+            "npmlog": "2.0.2",
             "osenv": "0.1.3",
-            "path-array": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-            "request": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "path-array": "1.0.1",
+            "request": "2.69.0",
+            "rimraf": "2.5.2",
+            "semver": "5.1.0",
             "tar": "2.2.1",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.4.tgz"
+            "which": "1.2.4"
           },
           "dependencies": {
             "glob": {
               "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "1.0.4",
                 "inherits": "2.0.1",
                 "minimatch": "2.0.10",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                "once": "1.3.3"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
+                    "brace-expansion": "1.1.3"
                   },
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
+                      "version": "1.1.3",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
+                          "version": "0.3.0",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
-                          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "version": "0.0.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -7635,92 +7884,92 @@
               }
             },
             "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "version": "2.7.3",
+                  "bundled": true,
                   "dev": true
                 },
                 "sigmund": {
-                  "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "version": "1.0.1",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "path-array": {
-              "version": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-              "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+              "version": "1.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "array-index": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
+                "array-index": "1.0.0"
               },
               "dependencies": {
                 "array-index": {
-                  "version": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-                  "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+                  "version": "1.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    "debug": "2.2.0",
+                    "es6-symbol": "3.0.2"
                   },
                   "dependencies": {
                     "debug": {
-                      "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                      "version": "2.2.0",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        "ms": "0.7.1"
                       },
                       "dependencies": {
                         "ms": {
-                          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                          "version": "0.7.1",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "es6-symbol": {
-                      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                      "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
+                      "version": "3.0.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.11"
                       },
                       "dependencies": {
                         "d": {
-                          "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                          "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+                          "version": "0.1.1",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                            "es5-ext": "0.10.11"
                           }
                         },
                         "es5-ext": {
-                          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-                          "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
+                          "version": "0.10.11",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                            "es6-iterator": "2.0.0",
+                            "es6-symbol": "3.0.2"
                           },
                           "dependencies": {
                             "es6-iterator": {
-                              "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                              "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                              "version": "2.0.0",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
-                                "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-                                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                                "d": "0.1.1",
+                                "es5-ext": "0.10.11",
+                                "es6-symbol": "3.0.2"
                               }
                             }
                           }
@@ -7734,8 +7983,8 @@
           }
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "3.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1.0.7"
@@ -7743,34 +7992,31 @@
         },
         "normalize-git-url": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.1.tgz",
-          "integrity": "sha1-1A1BnQWhWHAnHlBTTbt7jM2bClw=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
+            "hosted-git-info": "2.1.4",
             "is-builtin-module": "1.0.0",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "validate-npm-package-license": "3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
-                  "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                  "version": "1.1.1",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -7779,30 +8025,165 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "5.1.0"
+          }
+        },
+        "npm-package-arg": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.1.4",
+            "semver": "5.1.0"
+          }
+        },
+        "npm-registry-client": {
+          "version": "7.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "concat-stream": "1.5.1",
+            "graceful-fs": "4.1.3",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.3.5",
+            "npm-package-arg": "4.1.0",
+            "npmlog": "2.0.2",
+            "once": "1.3.3",
+            "request": "2.69.0",
+            "retry": "0.8.0",
+            "rimraf": "2.5.2",
+            "semver": "5.1.0",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "readable-stream": "2.0.5",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.8.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "npm-user-validate": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz",
-          "integrity": "sha1-1YXaC0fJ9BqebKaEtv2EukHr6H0=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+          "version": "2.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
+            "are-we-there-yet": "1.0.6",
             "gauge": "1.2.7"
+          },
+          "dependencies": {
+            "ansi": {
+              "version": "0.3.1",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.0.5"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "gauge": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi": "0.3.1",
+                "has-unicode": "2.0.0",
+                "lodash.pad": "4.1.0",
+                "lodash.padend": "4.2.0",
+                "lodash.padstart": "4.2.0"
+              },
+              "dependencies": {
+                "lodash.pad": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.repeat": "4.0.0",
+                    "lodash.tostring": "4.1.1"
+                  }
+                },
+                "lodash.padend": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.repeat": "4.0.0",
+                    "lodash.tostring": "4.1.1"
+                  }
+                },
+                "lodash.padstart": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.repeat": "4.0.0",
+                    "lodash.tostring": "4.1.1"
+                  }
+                },
+                "lodash.repeat": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lodash.tostring": "4.1.1"
+                  }
+                },
+                "lodash.tostring": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "version": "1.3.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.1"
@@ -7810,14 +8191,12 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "1.0.1",
@@ -7826,28 +8205,24 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+              "bundled": true,
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
+          "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "0.0.5"
@@ -7855,160 +8230,254 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            "graceful-fs": "4.1.3"
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "read-package-json": "2.0.13",
+            "graceful-fs": "4.1.3",
+            "read-package-json": "2.0.3",
             "readdir-scoped-modules": "1.0.2",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+            "semver": "5.1.0",
             "slide": "1.1.6",
-            "util-extend": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
+            "util-extend": "1.0.3"
           },
           "dependencies": {
             "util-extend": {
-              "version": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+              "version": "1.0.3",
+              "bundled": true,
               "dev": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "6.0.4",
+            "graceful-fs": "4.1.3",
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.3.5"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.3"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "json-parse-helpfulerror": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jju": "1.2.1"
+              },
+              "dependencies": {
+                "jju": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.2.tgz",
-          "integrity": "sha1-46SIeS9Az0cIGfAaYQ5xnWTwkJQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "read-package-json": "2.0.13",
+            "once": "1.3.3",
+            "read-package-json": "2.0.3",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+          "version": "2.0.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+            "process-nextick-args": "1.0.6",
             "string_decoder": "0.10.31",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "process-nextick-args": {
-              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
               "dev": true
             },
             "util-deprecate": {
-              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+            "graceful-fs": "4.1.3",
+            "once": "1.3.3"
+          }
+        },
+        "realize-package-specifier": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dezalgo": "1.0.3",
+            "npm-package-arg": "4.1.0"
           }
         },
         "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-          "integrity": "sha1-z5HS4AB1KxIXFVwAUkGRGZGiNGo=",
+          "version": "2.69.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
-            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
-            "bl": "https://registry.npmjs.org/bl/-/bl-1.0.1.tgz",
+            "aws4": "1.2.1",
+            "bl": "1.0.1",
             "caseless": "0.11.0",
             "combined-stream": "1.0.5",
             "extend": "3.0.0",
             "forever-agent": "0.6.1",
             "form-data": "1.0.0-rc3",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+            "mime-types": "2.1.9",
+            "node-uuid": "1.4.7",
             "oauth-sign": "0.8.0",
-            "qs": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+            "qs": "6.0.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
           },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true
             },
             "aws4": {
-              "version": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
-              "integrity": "sha1-UrVlmk0yWD1AX2XhEkrENtB/5aw=",
+              "version": "1.2.1",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                "lru-cache": "2.7.3"
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "version": "2.7.3",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "bl": {
-              "version": "https://registry.npmjs.org/bl/-/bl-1.0.1.tgz",
-              "integrity": "sha1-Dm33MwMIxGUVdRZ2yvpzNNyYUv0=",
+              "version": "1.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                "readable-stream": "2.0.5"
               }
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -8016,61 +8485,56 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                "async": "1.5.2",
                 "combined-stream": "1.0.5",
-                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                "mime-types": "2.1.9"
               },
               "dependencies": {
                 "async": {
-                  "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "version": "1.5.2",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "version": "2.0.6",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "1.1.1",
                 "commander": "2.9.0",
-                "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                "is-my-json-valid": "2.12.4",
+                "pinkie-promise": "2.0.0"
               },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-styles": "2.1.0",
-                    "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                    "escape-string-regexp": "1.0.4",
                     "has-ansi": "2.0.0",
                     "strip-ansi": "3.0.0",
                     "supports-color": "2.0.0"
@@ -8078,19 +8542,17 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
-                      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                      "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8=",
+                      "version": "1.0.4",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.0.0"
@@ -8098,16 +8560,14 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-readlink": "1.0.1"
@@ -8115,33 +8575,30 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-                  "integrity": "sha1-1O0rwdf4ja+ND3Y7Pj45ppvTeIA=",
+                  "version": "2.12.4",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "generate-function": "2.0.0",
                     "generate-object-property": "1.2.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-property": "1.0.2"
@@ -8149,36 +8606,34 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "xtend": {
-                      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "version": "4.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
-                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "version": "2.0.0",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    "pinkie": "2.0.1"
                   },
                   "dependencies": {
                     "pinkie": {
-                      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                      "version": "2.0.1",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -8186,19 +8641,19 @@
               }
             },
             "hawk": {
-              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "version": "3.1.3",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                "boom": "2.10.1",
                 "cryptiles": "2.0.5",
                 "hoek": "2.16.3",
                 "sntp": "1.0.9"
               },
               "dependencies": {
                 "boom": {
-                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "version": "2.10.1",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -8206,23 +8661,20 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    "boom": "2.10.1"
                   }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.16.3"
@@ -8231,104 +8683,104 @@
               }
             },
             "http-signature": {
-              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "version": "1.1.1",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
+                "assert-plus": "0.2.0",
+                "jsprim": "1.2.2",
+                "sshpk": "1.7.3"
               },
               "dependencies": {
                 "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "version": "0.2.0",
+                  "bundled": true,
                   "dev": true
                 },
                 "jsprim": {
-                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "version": "1.2.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
                   },
                   "dependencies": {
                     "extsprintf": {
-                      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "json-schema": {
-                      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "version": "0.2.2",
+                      "bundled": true,
                       "dev": true
                     },
                     "verror": {
-                      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "version": "1.3.6",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        "extsprintf": "1.0.2"
                       }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
-                  "integrity": "sha1-yqjvleMHZdhWaYtwJfnyEatlli8=",
+                  "version": "1.7.3",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
-                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    "asn1": "0.2.3",
+                    "assert-plus": "0.2.0",
+                    "dashdash": "1.12.2",
+                    "ecc-jsbn": "0.1.1",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.3"
                   },
                   "dependencies": {
                     "asn1": {
-                      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "version": "0.2.3",
+                      "bundled": true,
                       "dev": true
                     },
                     "dashdash": {
-                      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
-                      "integrity": "sha1-HG9wWISY0Ee4zVd3syuoWl4lvjY=",
+                      "version": "1.12.2",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        "assert-plus": "0.2.0"
                       }
                     },
                     "ecc-jsbn": {
-                      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "version": "0.1.1",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jodid25519": {
-                      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "version": "1.0.2",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jsbn": {
-                      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "version": "0.1.0",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                      "version": "0.13.3",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -8337,126 +8789,107 @@
               }
             },
             "is-typedarray": {
-              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
-              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "integrity": "sha1-37OWdktf33W+NLH0EEvDaH+2Nfg=",
+              "version": "2.1.9",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                "mime-db": "1.21.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                  "integrity": "sha1-m1I54zU89usBWgDYkCYQJ8NtS6w=",
+                  "version": "1.21.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-uuid": {
-              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "version": "1.4.7",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+              "bundled": true,
               "dev": true
             },
             "qs": {
-              "version": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
-              "integrity": "sha1-iMaNWQ6O1Wx2x581LBe5gkZqv80=",
+              "version": "6.0.2",
+              "bundled": true,
               "dev": true
             },
             "stringstream": {
-              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "version": "0.0.5",
+              "bundled": true,
               "dev": true
             },
             "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "version": "2.2.1",
+              "bundled": true,
               "dev": true
             },
             "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "version": "0.4.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "retry": {
-          "version": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
-          "integrity": "sha1-b2l+UKDk3cjI9/tUeptg3q1DZ40=",
+          "version": "0.9.0",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "version": "2.5.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz"
+            "glob": "7.0.0"
           }
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "version": "5.1.0",
+          "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+            "graceful-fs": "4.1.3",
+            "readable-stream": "2.0.5"
           }
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "sorted-object": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
-          "integrity": "sha1-XR9PnB+yzUiWWWcwTiEutEz7bQU=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.0.0"
@@ -8464,8 +8897,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.8",
@@ -8475,8 +8907,7 @@
           "dependencies": {
             "block-stream": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-              "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "2.0.1"
@@ -8486,73 +8917,83 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "unique-filename": {
-          "version": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.2"
           },
           "dependencies": {
             "spdx-correct": {
-              "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                "spdx-license-ids": "1.2.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
-                  "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                  "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
+                  "version": "1.2.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "spdx-expression-parse": {
-              "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-exceptions": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                "spdx-license-ids": "1.2.2"
+                "spdx-exceptions": "1.0.4",
+                "spdx-license-ids": "1.2.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
-                  "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "spdx-license-ids": {
+                  "version": "1.2.0",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -8561,8 +9002,7 @@
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -8570,25 +9010,23 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-          "integrity": "sha1-FVf5YIBgTlsRs1meufRbUKnv1yI=",
+          "version": "1.2.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-absolute": "0.1.7",
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz"
+            "isexe": "1.1.1"
           },
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-relative": "0.1.3"
@@ -8596,55 +9034,33 @@
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz",
-              "integrity": "sha1-8NR5PtL7XEa/3qt2C7uWX0SFpmw=",
+              "version": "1.1.1",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "graceful-fs": "4.1.3",
+            "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
         }
-      }
-    },
-    "npm-install-checks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-      "dev": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
-    "npm-package-arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.1.tgz",
-      "integrity": "sha1-htncqYW0xeXVl3Lf1d5pGZmKSVo=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.6.0",
-        "semver": "5.5.0"
       }
     },
     "npm-path": {
@@ -8656,55 +9072,6 @@
         "which": "1.3.0"
       }
     },
-    "npm-registry-client": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.0.9.tgz",
-      "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
-      "dev": true,
-      "requires": {
-        "chownr": "1.0.1",
-        "concat-stream": "1.6.2",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "4.1.1",
-        "npmlog": "2.0.4",
-        "once": "1.4.0",
-        "request": "2.85.0",
-        "retry": "0.8.0",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "slide": "1.1.6"
-      },
-      "dependencies": {
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        },
-        "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
-          }
-        }
-      }
-    },
     "npm-run-all": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.2.tgz",
@@ -8712,7 +9079,7 @@
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "cross-spawn": "5.1.0",
         "memorystream": "0.3.1",
         "minimatch": "3.0.4",
@@ -8807,12 +9174,6 @@
         "semver": "4.3.6"
       },
       "dependencies": {
-        "builtins": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-          "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
-          "dev": true
-        },
         "npm": {
           "version": "2.15.12",
           "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.12.tgz",
@@ -8837,7 +9198,7 @@
             "editor": "1.0.0",
             "fs-vacuum": "1.2.9",
             "fs-write-stream-atomic": "1.0.8",
-            "fstream": "1.0.11",
+            "fstream": "1.0.10",
             "fstream-npm": "1.1.1",
             "github-url-from-git": "1.4.0",
             "github-url-from-username-repo": "1.0.2",
@@ -8866,7 +9227,7 @@
             "once": "1.4.0",
             "opener": "1.4.1",
             "osenv": "0.1.3",
-            "path-is-inside": "1.0.2",
+            "path-is-inside": "1.0.1",
             "read": "1.0.7",
             "read-installed": "4.0.3",
             "read-package-json": "2.0.4",
@@ -8894,32 +9255,45 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "bundled": true,
               "dev": true
             },
             "ansi": {
               "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-              "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+              "bundled": true,
               "dev": true
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+              "bundled": true,
+              "dev": true
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "bundled": true,
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+              "bundled": true,
               "dev": true
+            },
+            "async-some": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "dezalgo": "1.0.3"
+              }
             },
             "block-stream": {
               "version": "0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "2.0.3"
@@ -8927,26 +9301,22 @@
             },
             "char-spinner": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-              "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
+              "bundled": true,
               "dev": true
             },
             "chmodr": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-              "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
+              "bundled": true,
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+              "bundled": true,
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.6",
@@ -8955,8 +9325,7 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "strip-ansi": "3.0.1",
@@ -8965,8 +9334,7 @@
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-                  "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "defaults": "1.0.3"
@@ -8974,8 +9342,7 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "clone": "1.0.2"
@@ -8983,8 +9350,7 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -8995,8 +9361,7 @@
             },
             "config-chain": {
               "version": "1.1.10",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-              "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ini": "1.3.4",
@@ -9005,33 +9370,45 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asap": "2.0.3",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+              "bundled": true,
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.9",
-              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
-              "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.6",
-                "path-is-inside": "1.0.2",
+                "path-is-inside": "1.0.1",
                 "rimraf": "2.5.4"
               }
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
-              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
-              "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.6",
@@ -9042,16 +9419,25 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
+            "fstream": {
+              "version": "1.0.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.6",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.5.4"
+              }
+            },
             "fstream-npm": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
-              "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fstream-ignore": "1.0.5",
@@ -9060,11 +9446,10 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fstream": "1.0.11",
+                    "fstream": "1.0.10",
                     "inherits": "2.0.3",
                     "minimatch": "3.0.3"
                   }
@@ -9073,14 +9458,17 @@
             },
             "github-url-from-git": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-              "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
+              "bundled": true,
+              "dev": true
+            },
+            "github-url-from-username-repo": {
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true
             },
             "glob": {
               "version": "7.0.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-              "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -9093,40 +9481,34 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.6",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-              "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
+              "bundled": true,
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-              "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+              "bundled": true,
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+              "bundled": true,
               "dev": true
             },
             "inflight": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -9135,20 +9517,17 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "bundled": true,
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+              "bundled": true,
               "dev": true
             },
             "init-package-json": {
               "version": "1.9.4",
-              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
-              "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "6.0.4",
@@ -9163,8 +9542,7 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inflight": "1.0.5",
@@ -9176,16 +9554,14 @@
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "promzard": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "read": "1.0.7"
@@ -9195,14 +9571,12 @@
             },
             "lockfile": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-              "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+              "bundled": true,
               "dev": true
             },
             "lru-cache": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pseudomap": "1.0.2",
@@ -9211,22 +9585,19 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                  "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "minimatch": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.6"
@@ -9234,8 +9605,7 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "balanced-match": "0.4.2",
@@ -9244,14 +9614,12 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -9260,8 +9628,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -9269,19 +9636,17 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-gyp": {
               "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
-              "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "fstream": "1.0.11",
+                "fstream": "1.0.10",
                 "glob": "7.0.6",
                 "graceful-fs": "4.1.6",
                 "minimatch": "3.0.3",
@@ -9298,22 +9663,27 @@
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.9"
+              }
+            },
             "normalize-git-url": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-              "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
+              "bundled": true,
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.1.5",
@@ -9324,8 +9694,7 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "builtin-modules": "1.1.0"
@@ -9333,8 +9702,7 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                      "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -9343,14 +9711,12 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+              "bundled": true,
               "dev": true
             },
             "npm-install-checks": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
-              "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "npmlog": "2.0.4",
@@ -9359,8 +9725,7 @@
             },
             "npm-package-arg": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
-              "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.1.5",
@@ -9369,8 +9734,7 @@
             },
             "npm-registry-client": {
               "version": "7.2.1",
-              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
-              "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "concat-stream": "1.5.2",
@@ -9387,8 +9751,7 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-                  "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inherits": "2.0.3",
@@ -9398,8 +9761,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "core-util-is": "1.0.2",
@@ -9412,62 +9774,53 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "bundled": true,
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "retry": {
                   "version": "0.10.0",
-                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-                  "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "npm-user-validate": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-              "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
+              "bundled": true,
               "dev": true
             },
             "npmlog": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-              "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "0.3.1",
@@ -9477,8 +9830,7 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delegates": "1.0.0",
@@ -9487,16 +9839,14 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "gauge": {
                   "version": "1.2.7",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-                  "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi": "0.3.1",
@@ -9508,26 +9858,22 @@
                   "dependencies": {
                     "has-unicode": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
-                      "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+                      "bundled": true,
                       "dev": true
                     },
                     "lodash._baseslice": {
                       "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
-                      "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "lodash._basetostring": {
                       "version": "4.12.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
-                      "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "lodash.pad": {
                       "version": "4.4.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
-                      "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "4.0.0",
@@ -9537,8 +9883,7 @@
                     },
                     "lodash.padend": {
                       "version": "4.5.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
-                      "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "4.0.0",
@@ -9548,8 +9893,7 @@
                     },
                     "lodash.padstart": {
                       "version": "4.5.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
-                      "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "4.0.0",
@@ -9559,8 +9903,7 @@
                     },
                     "lodash.tostring": {
                       "version": "4.1.4",
-                      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-                      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -9569,8 +9912,7 @@
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -9578,14 +9920,12 @@
             },
             "opener": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-              "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+              "bundled": true,
               "dev": true
             },
             "osenv": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "os-homedir": "1.0.0",
@@ -9594,22 +9934,24 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
-                  "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
+                  "bundled": true,
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "read": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "mute-stream": "0.0.5"
@@ -9617,16 +9959,51 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "read-installed": {
+              "version": "4.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debuglog": "1.0.1",
+                "graceful-fs": "4.1.6",
+                "read-package-json": "2.0.4",
+                "readdir-scoped-modules": "1.0.2",
+                "semver": "5.1.0",
+                "slide": "1.1.6",
+                "util-extend": "1.0.1"
+              },
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "debuglog": "1.0.1",
+                    "dezalgo": "1.0.3",
+                    "graceful-fs": "4.1.6",
+                    "once": "1.4.0"
+                  }
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
-              "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "6.0.4",
@@ -9637,8 +10014,7 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inflight": "1.0.5",
@@ -9650,16 +10026,14 @@
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "jju": "1.3.0"
@@ -9667,8 +10041,7 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -9677,8 +10050,7 @@
             },
             "readable-stream": {
               "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "buffer-shims": "1.0.0",
@@ -9692,46 +10064,39 @@
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                  "bundled": true,
                   "dev": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "bundled": true,
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                  "bundled": true,
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "realize-package-specifier": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
-              "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "dezalgo": "1.0.3",
@@ -9740,8 +10105,7 @@
             },
             "request": {
               "version": "2.74.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-              "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "aws-sign2": "0.6.0",
@@ -9769,20 +10133,17 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-                  "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "bl": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-                  "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "readable-stream": "2.0.6"
@@ -9790,8 +10151,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "core-util-is": "1.0.2",
@@ -9804,32 +10164,27 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "bundled": true,
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -9838,14 +10193,12 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "bundled": true,
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "delayed-stream": "1.0.0"
@@ -9853,28 +10206,24 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "bundled": true,
                   "dev": true
                 },
                 "form-data": {
                   "version": "1.0.0-rc4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-                  "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "async": "1.5.2",
@@ -9884,16 +10233,14 @@
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "chalk": "1.1.3",
@@ -9904,8 +10251,7 @@
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-styles": "2.2.1",
@@ -9917,20 +10263,17 @@
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                          "bundled": true,
                           "dev": true
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "ansi-regex": "2.0.0"
@@ -9938,16 +10281,14 @@
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-readlink": "1.0.1"
@@ -9955,16 +10296,14 @@
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                      "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "generate-function": "2.0.0",
@@ -9975,14 +10314,12 @@
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "bundled": true,
                           "dev": true
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-property": "1.0.2"
@@ -9990,30 +10327,26 @@
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                          "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                          "bundled": true,
                           "dev": true
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "pinkie": "2.0.4"
@@ -10021,8 +10354,7 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -10031,8 +10363,7 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "boom": "2.10.1",
@@ -10043,8 +10374,7 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hoek": "2.16.3"
@@ -10052,8 +10382,7 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "boom": "2.10.1"
@@ -10061,14 +10390,12 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hoek": "2.16.3"
@@ -10078,8 +10405,7 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "assert-plus": "0.2.0",
@@ -10089,14 +10415,12 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-                      "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2",
@@ -10106,20 +10430,17 @@
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "bundled": true,
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.2",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                          "bundled": true,
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -10129,8 +10450,7 @@
                     },
                     "sshpk": {
                       "version": "1.9.2",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
-                      "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "asn1": "0.2.3",
@@ -10145,20 +10465,17 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "bundled": true,
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "dashdash": {
                           "version": "1.14.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "assert-plus": "1.0.0"
@@ -10166,8 +10483,7 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -10176,8 +10492,7 @@
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "assert-plus": "1.0.0"
@@ -10185,8 +10500,7 @@
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -10195,15 +10509,13 @@
                         },
                         "jsbn": {
                           "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.13.3",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -10213,26 +10525,22 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "bundled": true,
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.11",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "mime-db": "1.23.0"
@@ -10240,60 +10548,51 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.23.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "qs": {
                   "version": "6.2.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-                  "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+                  "bundled": true,
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-                  "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-              "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
+              "bundled": true,
               "dev": true
             },
             "rimraf": {
               "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "7.0.6"
@@ -10301,14 +10600,12 @@
             },
             "semver": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-              "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+              "bundled": true,
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.6",
@@ -10317,8 +10614,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                  "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "core-util-is": "1.0.1",
@@ -10331,32 +10627,27 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                      "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10365,47 +10656,55 @@
             },
             "slide": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+              "bundled": true,
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
-              "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
+              "bundled": true,
               "dev": true
             },
             "spdx-license-ids": {
               "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+              "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "2.0.0"
               }
             },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.10",
+                "inherits": "2.0.3"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
             "uid-number": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+              "bundled": true,
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+              "bundled": true,
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-correct": "1.0.2",
@@ -10414,8 +10713,7 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "spdx-license-ids": "1.2.2"
@@ -10423,8 +10721,7 @@
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                  "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "spdx-exceptions": "1.0.4",
@@ -10433,18 +10730,31 @@
                   "dependencies": {
                     "spdx-exceptions": {
                       "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                      "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 }
               }
             },
+            "validate-npm-package-name": {
+              "version": "2.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "builtins": "0.0.7"
+              },
+              "dependencies": {
+                "builtins": {
+                  "version": "0.0.7",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
             "which": {
               "version": "1.2.11",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "1.1.2"
@@ -10452,17 +10762,25 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "bundled": true,
               "dev": true
+            },
+            "write-file-atomic": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.6",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
             }
           }
         },
@@ -10471,26 +10789,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
-        },
-        "validate-npm-package-name": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
-          "dev": true,
-          "requires": {
-            "builtins": "0.0.7"
-          }
-        },
-        "write-file-atomic": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
         }
       }
     },
@@ -10510,12 +10808,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
@@ -10857,7 +11149,7 @@
         "browserify-aes": "1.2.0",
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-github-repo-url": {
@@ -10992,23 +11284,17 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
-        "ripemd160": "2.0.1",
+        "ripemd160": "2.0.2",
         "safe-buffer": "5.1.1",
         "sha.js": "2.4.11"
       }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -11086,9 +11372,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
+      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
       "dev": true
     },
     "pretty-ms": {
@@ -11169,15 +11455,6 @@
       "dev": true,
       "requires": {
         "asap": "2.0.6"
-      }
-    },
-    "promzard": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-      "dev": true,
-      "requires": {
-        "read": "1.0.7"
       }
     },
     "prop-types": {
@@ -11535,15 +11812,6 @@
         }
       }
     },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dev": true,
-      "requires": {
-        "mute-stream": "0.0.7"
-      }
-    },
     "read-cmd-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
@@ -11551,34 +11819,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
-      }
-    },
-    "read-installed": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-      "dev": true,
-      "requires": {
-        "debuglog": "1.0.1",
-        "graceful-fs": "4.1.11",
-        "read-package-json": "2.0.13",
-        "readdir-scoped-modules": "1.0.2",
-        "semver": "5.5.0",
-        "slide": "1.1.6",
-        "util-extend": "1.0.3"
-      }
-    },
-    "read-package-json": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-      "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.2",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
       }
     },
     "read-pkg": {
@@ -11617,18 +11857,6 @@
         "util-deprecate": "1.0.2"
       }
     },
-    "readdir-scoped-modules": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-      "dev": true,
-      "requires": {
-        "debuglog": "1.0.1",
-        "dezalgo": "1.0.3",
-        "graceful-fs": "4.1.11",
-        "once": "1.4.0"
-      }
-    },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
@@ -11639,16 +11867,6 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
-      }
-    },
-    "realize-package-specifier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
-      "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3",
-        "npm-package-arg": "4.1.1"
       }
     },
     "redent": {
@@ -11906,44 +12124,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-          "dev": true
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11973,9 +12153,9 @@
       }
     },
     "resolve": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
-      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -12018,12 +12198,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "retry": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
-      "integrity": "sha1-I2dijcDtskex6rZJ3FOshiisLV8=",
-      "dev": true
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -12043,24 +12217,13 @@
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
+        "hash-base": "3.0.4",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "hash-base": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-          "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        }
       }
     },
     "rollup": {
@@ -12116,7 +12279,7 @@
       "requires": {
         "builtin-modules": "2.0.0",
         "is-module": "1.0.0",
-        "resolve": "1.7.0"
+        "resolve": "1.7.1"
       },
       "dependencies": {
         "builtin-modules": {
@@ -12162,7 +12325,7 @@
       "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
       "dev": true,
       "requires": {
-        "uglify-js": "3.3.20"
+        "uglify-js": "3.3.22"
       },
       "dependencies": {
         "source-map": {
@@ -12172,9 +12335,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.20",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.20.tgz",
-          "integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
+          "version": "3.3.22",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.22.tgz",
+          "integrity": "sha512-tqw96rL6/BG+7LM5VItdhDjTQmL5zG/I0b2RqWytlgeHe2eydZHuBHdA9vuGpCDhH/ZskNGcqDhivoR2xt8RIw==",
           "dev": true,
           "requires": {
             "commander": "2.15.1",
@@ -12218,9 +12381,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.9.tgz",
-      "integrity": "sha512-DHG9AHmCmgaFWgjBcXp6NxFDmh3MvIA62GqTWmLnTzr/3oZ6h5hLD8NA+9j+GF0jEwklNIpI4KuuyLG8UWMEvQ==",
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
@@ -12431,12 +12594,6 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -12554,15 +12711,6 @@
         "kind-of": "3.2.2"
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -12676,22 +12824,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
     },
     "staged-git-files": {
       "version": "0.0.4",
@@ -12828,12 +12960,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -12876,7 +13002,7 @@
         "byline": "5.0.0",
         "duplexer": "0.1.1",
         "minimist": "0.1.0",
-        "moment": "2.22.0",
+        "moment": "2.22.1",
         "through": "2.3.8"
       },
       "dependencies": {
@@ -12889,9 +13015,9 @@
       }
     },
     "supports-color": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
         "has-flag": "3.0.0"
@@ -12910,7 +13036,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
@@ -13033,17 +13159,6 @@
         }
       }
     },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
-    },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -13123,9 +13238,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
-      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -13194,23 +13309,6 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -13241,22 +13339,6 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -13283,9 +13365,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
       "dev": true
     },
     "typings-tester": {
@@ -13407,15 +13489,6 @@
             "to-object-path": "0.3.0"
           }
         }
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "0.1.4"
       }
     },
     "universalify": {
@@ -13579,12 +13652,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "util-extend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
-      "dev": true
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -13616,31 +13683,11 @@
         "spdx-expression-parse": "3.0.0"
       }
     },
-    "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "dev": true,
-      "requires": {
-        "builtins": "1.0.3"
-      }
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
     },
     "vlq": {
       "version": "0.2.3",
@@ -13737,6 +13784,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
+            "fsevents": "1.2.2",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -14123,9 +14171,9 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.0.tgz",
-      "integrity": "sha512-kmjTZ6WXZowuBfTk1/H/scmyp09eHwPpqF2mHRZ9WMCBlQ61NSkqZ25azPlPOeCIhva57PGrUyeTIW5X8Q7HEw==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.1.tgz",
+      "integrity": "sha512-wbjnvcc3HOPKRE/L0KmTv2MrByfLFOJlVFNKo5Svxy+1plR/bMIMYQDgB4pUOzJXhiBLU7Clp6P1SSzS89iKxA==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",


### PR DESCRIPTION
`npm run bootstrap` is broken, you can see the same problem on CI
Error log:
```
 Error: Command failed: npm install
npm WARN invalid config loglevel="notice"
npm ERR! Linux 4.14.12-041412-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v9.11.1/bin/node" "/home/travis/build/redux-saga/redux-saga/node_modules/.bin/npm" "install"
npm ERR! node v9.11.1
npm ERR! npm  v3.7.5
npm ERR! path /home/travis/build/redux-saga/redux-saga/node_modules/npm/node_modules/has-unicode
npm ERR! code ELOOP
npm ERR! errno -40
npm ERR! syscall stat
npm ERR! ELOOP: too many symbolic links encountered, stat '/home/travis/build/redux-saga/redux-saga/node_modules/npm/node_modules/has-unicode'
```