### PR TITLE
chore(fork): remove redundant code

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -130,10 +130,6 @@ function forkQueue(mainTask, onAbort, cb) {
 }
 
 function createTaskIterator({ context, fn, args }) {
-  if (is.iterator(fn)) {
-    return fn
-  }
-
   // catch synchronous failures; see #152 and #441
   let result, error
   try {


### PR DESCRIPTION
you can only fork a function or generator, you can't fork an iterator