### PR TITLE
chore: npm doesnt support node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - 8
+  - 9
 
 install:
   - npm run bootstrap


### PR DESCRIPTION
```sh
npm does not support Node.js v10.3.0
npm WARN npm You should probably upgrade to a newer version of node as we
npm WARN npm can't make any promises that npm will work with this version.
npm WARN npm Supported releases of Node.js are the latest release of 4, 6, 7, 8, 9.
```