### PR TITLE
Consider avoiding assumptions about how easy sagas/generators are

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![OpenCollective](https://opencollective.com/redux-saga/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/redux-saga/sponsors/badge.svg)](#sponsors)
 
-`redux-saga` is a library that aims to make application side effects (i.e. asynchronous things like data fetching and impure things like accessing the browser cache) easier to manage, more efficient to execute, simple to test, and better at handling failures.
+`redux-saga` is a library that aims to make application side effects (i.e. asynchronous things like data fetching and impure things like accessing the browser cache) easier to manage, more efficient to execute, easy to test, and better at handling failures.
 
 The mental model is that a saga is like a separate thread in your application that's solely responsible for side effects. `redux-saga` is a redux middleware, which means this thread can be started, paused and cancelled from the main application with normal redux actions, it has access to the full redux application state and it can dispatch redux actions as well.
 
@@ -175,7 +175,7 @@ There are three counter examples.
 
 Demo using vanilla JavaScript and UMD builds. All source is inlined in `index.html`.
 
-To launch the example, just open `index.html` in your browser.
+To launch the example, open `index.html` in your browser.
 
 > Important: your browser must support Generators. Latest versions of Chrome/Firefox/Edge are suitable.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -21,7 +21,7 @@ It will put the application into an infinite loop because `take()` only creates 
 
 Adding `yield` will pause the generator and return control to the Redux Saga middleware which will execute the effect. In case of `take()`, Redux Saga will wait for the next action matching the pattern, and only then will resume the generator.
 
-To fix the example above, simply `yield` the effect returned by `take()`:
+To fix the example above, `yield` the effect returned by `take()`:
 
 ```js
 import { take } from 'redux-saga/effects'

--- a/docs/advanced/Channels.md
+++ b/docs/advanced/Channels.md
@@ -77,7 +77,7 @@ function* watchRequests() {
 
 Like `actionChannel` (Effect), `eventChannel` (a factory function, not an Effect) creates a Channel for events but from event sources other than the Redux Store.
 
-This simple example creates a Channel from an interval:
+This basic example creates a Channel from an interval:
 
 ```javascript
 import { eventChannel, END } from 'redux-saga'
@@ -131,7 +131,7 @@ export function* saga() {
 }
 ```
 
-So the Saga is yielding a `take(chan)`. This causes the Saga to block until a message is put on the channel. In our example above, it corresponds to when we invoke `emitter(secs)`. Note also we're executing the whole `while (true) {...}` loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by invoking `emitter(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel. In our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga simply terminates).
+So the Saga is yielding a `take(chan)`. This causes the Saga to block until a message is put on the channel. In our example above, it corresponds to when we invoke `emitter(secs)`. Note also we're executing the whole `while (true) {...}` loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by invoking `emitter(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel. In our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga terminates).
 
 The subscriber returns an `unsubscribe` function. This is used by the channel to unsubscribe before the event source complete. Inside a Saga consuming messages from an event channel, if we want to *exit early* before the event source complete (e.g. Saga has been cancelled) you can call `chan.close()` to close the channel and unsubscribe from the source.
 
@@ -270,6 +270,6 @@ function* handleRequest(chan) {
 
 In the above example, we create a channel using the `channel` factory. We get back a channel which by default buffers all messages we put on it (unless there is a pending taker, in which the taker is resumed immediately with the message).
 
-The `watchRequests` saga then forks three worker sagas. Note the created channel is supplied to all forked sagas. `watchRequests` will use this channel to *dispatch* work to the three worker sagas. On each `REQUEST` action the Saga will simply put the payload on the channel. The payload will then be taken by any *free* worker. Otherwise it will be queued by the channel until a worker Saga is ready to take it.
+The `watchRequests` saga then forks three worker sagas. Note the created channel is supplied to all forked sagas. `watchRequests` will use this channel to *dispatch* work to the three worker sagas. On each `REQUEST` action the Saga will put the payload on the channel. The payload will then be taken by any *free* worker. Otherwise it will be queued by the channel until a worker Saga is ready to take it.
 
 All the three workers run a typical while loop. On each iteration, a worker will take the next request, or will block until a message is available. Note that this mechanism provides an automatic load-balancing between the 3 workers. Rapid workers are not slowed down by slow workers.

--- a/docs/advanced/ComposingSagas.md
+++ b/docs/advanced/ComposingSagas.md
@@ -6,7 +6,7 @@ While using `yield*` provides an idiomatic way of composing Sagas, this approach
 
 - More importantly, `yield*` allows only for sequential composition of tasks, so you can only `yield*` to one generator at a time.
 
-You can simply use `yield` to start one or more subtasks in parallel. When yielding a call to a generator, the Saga will wait for the generator to terminate before progressing, then resume with the returned value (or throws if an error propagates from the subtask).
+You can use `yield` to start one or more subtasks in parallel. When yielding a call to a generator, the Saga will wait for the generator to terminate before progressing, then resume with the returned value (or throws if an error propagates from the subtask).
 
 ```javascript
 function* fetchPosts() {

--- a/docs/advanced/ForkModel.md
+++ b/docs/advanced/ForkModel.md
@@ -69,7 +69,7 @@ In fact, attached forks shares the same semantics with the parallel Effect:
 
 
 And this applies for all other semantics as well (error and cancellation propagation). You can understand how
-attached forks behave by simply considering it as a *dynamic parallel* Effect.
+attached forks behave by considering it as a *dynamic parallel* Effect.
 
 ## Error propagation
 

--- a/docs/advanced/FutureActions.md
+++ b/docs/advanced/FutureActions.md
@@ -4,9 +4,9 @@ Until now we've used the helper effect `takeEvery` in order to spawn a new task 
 
 In reality, `takeEvery` is just a wrapper effect for internal helper function built on top of the lower-level and more powerful API. In this section we'll see a new Effect, `take`, which makes it possible to build complex control flow by allowing total control of the action observation process.
 
-## A simple logger
+## A basic logger
 
-Let's take a simple example of a Saga that watches all actions dispatched to the store and logs them to the console.
+Let's take a basic example of a Saga that watches all actions dispatched to the store and logs them to the console.
 
 Using `takeEvery('*')` (with the wildcard `*` pattern), we can catch all dispatched actions regardless of their types.
 
@@ -49,7 +49,7 @@ In the case of `take`, the control is inverted. Instead of the actions being *pu
 
 This inversion of control allows us to implement control flows that are non-trivial to do with the traditional *push* approach.
 
-As a simple example, suppose that in our Todo application, we want to watch user actions and show a congratulation message after the user has created his first three todos.
+As a basic example, suppose that in our Todo application, we want to watch user actions and show a congratulation message after the user has created his first three todos.
 
 ```javascript
 import { take, put } from 'redux-saga/effects'

--- a/docs/advanced/NonBlockingCalls.md
+++ b/docs/advanced/NonBlockingCalls.md
@@ -17,7 +17,7 @@ function* loginFlow() {
 
 Let's complete the example and implement the actual login/logout logic. Suppose we have an API which permits us to authorize the user on a remote server. If the authorization is successful, the server will return an authorization token which will be stored by our application using DOM storage (assume our API provides another service for DOM storage).
 
-When the user logs out, we'll simply delete the authorization token stored previously.
+When the user logs out, we'll delete the authorization token stored previously.
 
 ### First try
 
@@ -191,7 +191,7 @@ function* loginFlow() {
 
 We are *almost* done (concurrency is not that easy; you have to take it seriously).
 
-Suppose that when we receive a `LOGIN_REQUEST` action, our reducer sets some `isLoginPending` flag to true so it can display some message or spinner in the UI. If we get a `LOGOUT` in the middle of an API call and abort the task by simply *killing it* (i.e. the task is stopped right away), then we may end up again with an inconsistent state. We'll still have `isLoginPending` set to true and our reducer will be waiting for an outcome action (`LOGIN_SUCCESS` or `LOGIN_ERROR`).
+Suppose that when we receive a `LOGIN_REQUEST` action, our reducer sets some `isLoginPending` flag to true so it can display some message or spinner in the UI. If we get a `LOGOUT` in the middle of an API call and abort the task by *killing it* (i.e. the task is stopped right away), then we may end up again with an inconsistent state. We'll still have `isLoginPending` set to true and our reducer will be waiting for an outcome action (`LOGIN_SUCCESS` or `LOGIN_ERROR`).
 
 Fortunately, the `cancel` Effect won't brutally kill our `authorize` task, it'll instead give it a chance to perform its cleanup logic. The cancelled task can handle any cancellation logic (as well as any other type of completion) in its `finally` block. Since a finally block execute on any type of completion (normal return, error, or forced cancellation), there is an Effect `cancelled` which you can use if you want handle cancellation in a special way:
 
@@ -218,4 +218,4 @@ function* authorize(user, password) {
 You may have noticed that we haven't done anything about clearing our `isLoginPending` state. For that, there are at least two possible solutions:
 
 - dispatch a dedicated action `RESET_LOGIN_PENDING`
-- more simply, make the reducer clear the `isLoginPending` on a `LOGOUT` action
+- make the reducer clear the `isLoginPending` on a `LOGOUT` action

--- a/docs/advanced/RunningTasksInParallel.md
+++ b/docs/advanced/RunningTasksInParallel.md
@@ -1,6 +1,6 @@
 # Running Tasks In Parallel
 
-The `yield` statement is great for representing asynchronous control flow in a simple and linear style, but we also need to do things in parallel. We can't simply write:
+The `yield` statement is great for representing asynchronous control flow in a linear style, but we also need to do things in parallel. We can't write:
 
 ```javascript
 // wrong, effects will be executed in sequence

--- a/docs/advanced/SequencingSagas.md
+++ b/docs/advanced/SequencingSagas.md
@@ -1,6 +1,6 @@
 # Sequencing Sagas via `yield*`
 
-You can use the builtin `yield*` operator to compose multiple Sagas in a sequential way. This allows you to sequence your *macro-tasks* in a simple procedural style.
+You can use the builtin `yield*` operator to compose multiple Sagas in a sequential way. This allows you to sequence your *macro-tasks* in a procedural style.
 
 ```javascript
 function* playLevelOne() { ... }

--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -4,7 +4,7 @@ We saw already an example of cancellation in the [Non blocking calls](NonBlockin
 
 Once a task is forked, you can abort its execution using `yield cancel(task)`.
 
-To see how it works, let's consider a simple example: A background sync which can be started/stopped by some UI commands. Upon receiving a `START_BACKGROUND_SYNC` action, we fork a background task that will periodically sync some data from a remote server.
+To see how it works, let's consider a basic example: A background sync which can be started/stopped by some UI commands. Upon receiving a `START_BACKGROUND_SYNC` action, we fork a background task that will periodically sync some data from a remote server.
 
 The task will execute continually until a `STOP_BACKGROUND_SYNC` action is triggered. Then we cancel the background task and wait again for the next `START_BACKGROUND_SYNC` action.
 

--- a/docs/advanced/Testing.md
+++ b/docs/advanced/Testing.md
@@ -35,7 +35,7 @@ function* changeColorSaga() {
 }
 ```
 
-Since Sagas always yield an Effect, and these effects have simple factory functions (e.g. put, take etc.) a test may
+Since Sagas always yield an Effect, and these effects have basic factory functions (e.g. put, take etc.) a test may
 inspect the yielded effect and compare it to an expected effect. To get the first yielded value from a saga,
 call its `next().value`:
 
@@ -164,7 +164,7 @@ See also: [Task cancellation](TaskCancellation.md) for testing fork effects
 Although it may be useful to test each step of a saga, in practise this makes for brittle tests. Instead, it may be
 preferable to run the whole saga and assert that the expected effects have occurred.
 
-Suppose we have a simple saga which calls an HTTP API:
+Suppose we have a basic saga which calls an HTTP API:
 
 ```javascript
 function* callApi(url) {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -169,7 +169,7 @@ Spawns a `saga` on each action dispatched to the Store that matches `pattern`.
 
 #### Example
 
-In the following example, we create a simple task `fetchUser`. We use `takeEvery` to start a new `fetchUser` task on each dispatched `USER_REQUESTED` action:
+In the following example, we create a basic task `fetchUser`. We use `takeEvery` to start a new `fetchUser` task on each dispatched `USER_REQUESTED` action:
 
 ```javascript
 import { takeEvery } from `redux-saga/effects`
@@ -227,7 +227,7 @@ incoming action to the argument list (i.e. the action will be the last argument 
 
 #### Example
 
-In the following example, we create a simple task `fetchUser`. We use `takeLatest` to
+In the following example, we create a basic task `fetchUser`. We use `takeLatest` to
 start a new `fetchUser` task on each dispatched `USER_REQUESTED` action. Since `takeLatest`
 cancels any pending task started previously, we ensure that if a user triggers multiple consecutive
 `USER_REQUESTED` actions rapidly, we'll only conclude with the latest action
@@ -281,7 +281,7 @@ incoming action to the argument list (i.e. the action will be the last argument 
 
 #### Example
 
-In the following example, we create a simple task `fetchUser`. We use `takeLeading` to
+In the following example, we create a basic task `fetchUser`. We use `takeLeading` to
 start a new `fetchUser` task on each dispatched `USER_REQUESTED` action. Since `takeLeading`
 ignores any new coming task after it's started, we ensure that if a user triggers multiple consecutive
 `USER_REQUESTED` actions rapidly, we'll only keep on running with the leading action
@@ -330,7 +330,7 @@ incoming action to the argument list (i.e. the action will be the last argument 
 
 #### Example
 
-In the following example, we create a simple task `fetchAutocomplete`. We use `throttle` to
+In the following example, we create a basic task `fetchAutocomplete`. We use `throttle` to
 start a new `fetchAutocomplete` task on dispatched `FETCH_AUTOCOMPLETE` action. However since `throttle` ignores consecutive `FETCH_AUTOCOMPLETE` for some time, we ensure that user won't flood our server with requests.
 
 ```javascript
@@ -574,7 +574,7 @@ Creates an Effect description that instructs the middleware to wait for the resu
 
 #### Notes
 
-It simply wraps the array of tasks in [join effects](#jointask), roughly becoming the equivalent of
+It wraps the array of tasks in [join effects](#jointask), roughly becoming the equivalent of
 `yield tasks.map(t => join(t))`.
 
 ### `cancel(task)`
@@ -638,7 +638,7 @@ Creates an Effect description that instructs the middleware to cancel previously
 
 #### Notes
 
-It simply wraps the array of tasks in [cancel effects](#canceltask), roughly becoming the equivalent of
+It wraps the array of tasks in [cancel effects](#canceltask), roughly becoming the equivalent of
 `yield tasks.map(t => cancel(t))`.
 
 ### `cancel()`

--- a/docs/basics/DeclarativeEffects.md
+++ b/docs/basics/DeclarativeEffects.md
@@ -1,12 +1,12 @@
 # Declarative Effects
 
-In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic, we yield plain JavaScript Objects from the Generator. We call those Objects [*Effects*](https://redux-saga.js.org/docs/api/#effect-creators). An Effect is simply an object that contains some information to be interpreted by the middleware. You can view Effects like instructions to the middleware to perform some operation (e.g., invoke some asynchronous function, dispatch an action to the store, etc.).
+In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic, we yield plain JavaScript Objects from the Generator. We call those Objects [*Effects*](https://redux-saga.js.org/docs/api/#effect-creators). An Effect is an object that contains some information to be interpreted by the middleware. You can view Effects like instructions to the middleware to perform some operation (e.g., invoke some asynchronous function, dispatch an action to the store, etc.).
 
 To create Effects, you use the functions provided by the library in the `redux-saga/effects` package.
 
 In this section and the following, we will introduce some basic Effects. And see how the concept allows the Sagas to be easily tested.
 
-Sagas can yield Effects in multiple forms. The simplest way is to yield a Promise.
+Sagas can yield Effects in multiple forms. The easiest way is to yield a Promise.
 
 For example suppose we have a Saga that watches a `PRODUCTS_REQUESTED` action. On each matching action, it starts a task to fetch a list of products from a server.
 
@@ -37,7 +37,7 @@ assert.deepEqual(iterator.next().value, ??) // what do we expect ?
 
 We want to check the result of the first value yielded by the generator. In our case it's the result of running `Api.fetch('/products')` which is a Promise . Executing the real service during tests is neither a viable nor practical approach, so we have to *mock* the `Api.fetch` function, i.e. we'll have to replace the real function with a fake one which doesn't actually run the AJAX request but only checks that we've called `Api.fetch` with the right arguments (`'/products'` in our case).
 
-Mocks make testing more difficult and less reliable. On the other hand, functions that simply return values are easier to test, since we can use a simple `equal()` to check the result. This is the way to write the most reliable tests.
+Mocks make testing more difficult and less reliable. On the other hand, functions that return values are easier to test, since we can use a simple `equal()` to check the result. This is the way to write the most reliable tests.
 
 Not convinced? I encourage you to read [Eric Elliott's article](https://medium.com/javascript-scene/what-every-unit-test-needs-f6cd34d9836d#.4ttnnzpgc):
 
@@ -48,9 +48,9 @@ but most don’t:
 >
 > If you finish a test without answering those two questions, you don’t have a real unit test. You have a sloppy, half-baked test.
 
-What we actually need is just to make sure the `fetchProducts` task yields a call with the right function and the right arguments.
+What we actually need to do is make sure the `fetchProducts` task yields a call with the right function and the right arguments.
 
-Instead of invoking the asynchronous function directly from inside the Generator, **we can yield only a description of the function invocation**. i.e. We'll simply yield an object which looks like
+Instead of invoking the asynchronous function directly from inside the Generator, **we can yield only a description of the function invocation**. i.e. We'll yield an object which looks like
 
 ```javascript
 // Effect -> call the function Api.fetch with `./products` as argument
@@ -93,9 +93,9 @@ assert.deepEqual(
 )
 ```
 
-Now we don't need to mock anything, and a simple equality test will suffice.
+Now we don't need to mock anything, and a basic equality test will suffice.
 
-The advantage of those *declarative calls* is that we can test all the logic inside a Saga by simply iterating over the Generator and doing a `deepEqual` test on the values yielded successively. This is a real benefit, as your complex asynchronous operations are no longer black boxes, and you can test in detail their operational logic no matter how complex it is.
+The advantage of those *declarative calls* is that we can test all the logic inside a Saga by iterating over the Generator and doing a `deepEqual` test on the values yielded successively. This is a real benefit, as your complex asynchronous operations are no longer black boxes, and you can test in detail their operational logic no matter how complex it is.
 
 `call` also supports invoking object methods, you can provide a `this` context to the invoked functions using the following form:
 

--- a/docs/basics/DispatchingActions.md
+++ b/docs/basics/DispatchingActions.md
@@ -19,9 +19,9 @@ However, this solution has the same drawbacks as invoking functions directly fro
 the dispatch after receiving the AJAX response, we'll need again to mock the `dispatch`
 function.
 
-Instead, we need the same declarative solution. Just create an Object to instruct the
+Instead, we need the same declarative solution. Create a plain JavaScript Object to instruct the
 middleware that we need to dispatch some action, and let the middleware perform the real
-dispatch. This way we can test the Generator's dispatch in the same way: by just inspecting
+dispatch. This way we can test the Generator's dispatch in the same way: by inspecting
 the yielded Effect and making sure it contains the correct instructions.
 
 The library provides, for this purpose, another function `put` which creates the dispatch
@@ -66,5 +66,5 @@ assert.deepEqual(
 
 Note how we pass the fake response to the Generator via its `next` method. Outside the
 middleware environment, we have total control over the Generator, we can simulate a
-real environment by simply mocking results and resuming the Generator with them. Mocking
-data is a lot simpler than mocking functions and spying calls.
+real environment by mocking results and resuming the Generator with them. Mocking
+data is a lot easier than mocking functions and spying calls.

--- a/docs/basics/Effect.md
+++ b/docs/basics/Effect.md
@@ -2,7 +2,7 @@
 
 To generalize, triggering Side Effects from inside a Saga is always done by yielding some declarative Effect. (You can also yield Promise directly, but this will make testing difficult as we saw in the first section.)
 
-What a Saga does is actually compose all those Effects together to implement the desired control flow. The simplest example is to sequence yielded Effects by just putting the yields one after another. You can also use the familiar control flow operators (`if`, `while`, `for`) to implement more sophisticated control flows.
+What a Saga does is actually compose all those Effects together to implement the desired control flow. The most basic example is to sequence yielded Effects by putting the yields one after another. You can also use the familiar control flow operators (`if`, `while`, `for`) to implement more sophisticated control flows.
 
 We saw that using Effects like `call` and `put`, combined with high-level APIs like `takeEvery` allows us to achieve the same things as `redux-thunk`, but with the added benefit of easy testability.
 

--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -4,7 +4,7 @@
 
 This tutorial attempts to introduce redux-saga in a (hopefully) accessible way.
 
-For our getting started tutorial, we are going to use the trivial Counter demo from the Redux repo. The application is quite simple but is a good fit to illustrate the basic concepts of redux-saga without being lost in excessive details.
+For our getting started tutorial, we are going to use the trivial Counter demo from the Redux repo. The application is quite basic but is a good fit to illustrate the basic concepts of redux-saga without being lost in excessive details.
 
 ### The initial setup
 
@@ -25,7 +25,7 @@ To start the application, run:
 $ npm start
 ```
 
-We are starting with the simplest use case: 2 buttons to `Increment` and `Decrement` a counter. Later, we will introduce asynchronous calls.
+We are starting with the most basic use case: 2 buttons to `Increment` and `Decrement` a counter. Later, we will introduce asynchronous calls.
 
 If things go well, you should see 2 buttons `Increment` and `Decrement` along with a message below showing `Counter: 0`.
 
@@ -159,7 +159,7 @@ Sagas are implemented as [Generator functions](https://developer.mozilla.org/en-
 
 Once the Promise is resolved, the middleware will resume the Saga, executing code until the next yield. In this example, the next statement is another yielded object: the result of calling `put({type: 'INCREMENT'})`, which instructs the middleware to dispatch an `INCREMENT` action.
 
-`put` is one example of what we call an *Effect*. Effects are simple JavaScript objects which contain instructions to be fulfilled by the middleware. When a middleware retrieves an Effect yielded by a Saga, the Saga is paused until the Effect is fulfilled.
+`put` is one example of what we call an *Effect*. Effects are plain JavaScript objects which contain instructions to be fulfilled by the middleware. When a middleware retrieves an Effect yielded by a Saga, the Saga is paused until the Effect is fulfilled.
 
 So to summarize, the `incrementAsync` Saga sleeps for 1 second via the call to `delay(1000)`, then dispatches an `INCREMENT` action.
 
@@ -255,7 +255,7 @@ since there is no more yield the `done` field is set to true. And since the `inc
 Generator doesn't return anything (no `return` statement), the `value` field is set to
 `undefined`.
 
-So now, in order to test the logic inside `incrementAsync`, we'll simply have to iterate
+So now, in order to test the logic inside `incrementAsync`, we'll have to iterate
 over the returned Generator and check the values yielded by the generator.
 
 ```javascript
@@ -298,7 +298,7 @@ Instead of doing `yield delay(1000)`, we're now doing `yield call(delay, 1000)`.
 
 In the first case, the yield expression `delay(1000)` is evaluated before it gets passed to the caller of `next` (the caller could be the middleware when running our code. It could also be our test code which runs the Generator function and iterates over the returned Generator). So what the caller gets is a Promise, like in the test code above.
 
-In the second case, the yield expression `call(delay, 1000)` is what gets passed to the caller of `next`. `call` just like `put`, returns an Effect which instructs the middleware to call a given function with the given arguments. In fact, neither `put` nor `call` performs any dispatch or asynchronous call by themselves, they simply return plain JavaScript objects.
+In the second case, the yield expression `call(delay, 1000)` is what gets passed to the caller of `next`. `call` just like `put`, returns an Effect which instructs the middleware to call a given function with the given arguments. In fact, neither `put` nor `call` performs any dispatch or asynchronous call by themselves, they return plain JavaScript objects.
 
 ```javascript
 put({type: 'INCREMENT'}) // => { PUT: {type: 'INCREMENT'} }
@@ -342,7 +342,7 @@ test('incrementAsync Saga test', (assert) => {
 });
 ```
 
-Since `put` and `call` return plain objects, we can reuse the same functions in our test code. And to test the logic of `incrementAsync`, we simply iterate over the generator and do `deepEqual` tests on its values.
+Since `put` and `call` return plain objects, we can reuse the same functions in our test code. And to test the logic of `incrementAsync`, we iterate over the generator and do `deepEqual` tests on its values.
 
 In order to run the above test, run:
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -154,7 +154,7 @@ creates a higher order reducer to do most of the heavy lifting for the developer
 
 However, this method comes with overhead because it stores references to the previous state(s) of the application.
 
-Using redux-saga's `delay` and `race` we can implement a simple, one-time undo without enhancing
+Using redux-saga's `delay` and `race` we can implement a basic, one-time undo without enhancing
 our reducer or storing the previous state.
 
 ```javascript

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -214,7 +214,7 @@ export default function proc(
   )
 
   /**
-    cancellation of the main task. We'll resume the Generator with a Cancel
+    cancellation of the main task. We'll simply resume the Generator with a Cancel
   **/
   function cancelMain() {
     if (mainTask.isRunning && !mainTask.isCancelled) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -214,7 +214,7 @@ export default function proc(
   )
 
   /**
-    cancellation of the main task. We'll simply resume the Generator with a Cancel
+    cancellation of the main task. We'll resume the Generator with a Cancel
   **/
   function cancelMain() {
     if (mainTask.isRunning && !mainTask.isCancelled) {


### PR DESCRIPTION
First off, I really like the documentation of redux-sagas and it does help me learn to understand sagas in small steps.

One thing I couldn't avoid however is to feel uneasy about how the docs talk about beginner examples. Concepts and examples are presented as "simple" and "simply do this" while in all honesty some of the concepts are pretty hard to grasp, especially for beginners. 

I'd propose to change a lot of these sentences to use the word _basic_ instead. Basic means _the examples are slimmed down to their fundamentals_, but doesn't imply they are _easy_ or _simple to grasp_.

After all, if something is easy or not differs per person.