### PR TITLE
internal: Saga env

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -150,6 +150,7 @@ function createTaskIterator({ context, fn, args }) {
 
 export default function proc(env, iterator, parentContext, parentEffectId, meta, cont) {
   const taskContext = Object.create(parentContext)
+  const finalRunEffect = env.finalizeRunEffect(runEffect)
 
   let crashedEffect = null
   const cancelledDueToErrorTasks = []
@@ -413,16 +414,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
       env.sagaMonitor && env.sagaMonitor.effectCancelled(effectId)
     }
 
-    // if one can find a way to decouple runEffect from closure variables
-    // so it could be the call to it could be referentially transparent
-    // this potentially could be simplified, finalRunEffect created beforehand
-    // and this part of the code wouldnt have to know about middleware stuff
-    if (is.func(env.middleware)) {
-      env.middleware(eff => runEffect(eff, effectId, currCb))(effect)
-      return
-    }
-
-    runEffect(effect, effectId, currCb)
+    finalRunEffect(effect, effectId, currCb)
   }
 
   function resolvePromise(promise, cb) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -148,7 +148,7 @@ function createTaskIterator({ context, fn, args }) {
       )
 }
 
-export default function proc(iterator, parentContext = {}, env, parentEffectId = 0, meta, cont) {
+export default function proc(iterator, parentContext, parentEffectId, meta, env, cont) {
   const taskContext = Object.create(parentContext)
 
   let crashedEffect = null
@@ -436,7 +436,7 @@ export default function proc(iterator, parentContext = {}, env, parentEffectId =
   }
 
   function resolveIterator(iterator, effectId, meta, cb) {
-    proc(iterator, taskContext, env, effectId, meta, cb)
+    proc(iterator, taskContext, effectId, meta, env, cb)
   }
 
   function runTakeEffect({ channel = env.channel, pattern, maybe }, cb) {
@@ -521,7 +521,7 @@ export default function proc(iterator, parentContext = {}, env, parentEffectId =
     const meta = getIteratorMetaInfo(taskIterator, fn)
     try {
       suspend()
-      const task = proc(taskIterator, taskContext, env, effectId, meta, detached ? null : noop)
+      const task = proc(taskIterator, taskContext, effectId, meta, env, detached ? null : noop)
 
       if (detached) {
         cb(task)

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -148,7 +148,7 @@ function createTaskIterator({ context, fn, args }) {
       )
 }
 
-export default function proc(iterator, parentContext, parentEffectId, meta, env, cont) {
+export default function proc(env, iterator, parentContext, parentEffectId, meta, cont) {
   const taskContext = Object.create(parentContext)
 
   let crashedEffect = null
@@ -436,10 +436,10 @@ export default function proc(iterator, parentContext, parentEffectId, meta, env,
   }
 
   function resolveIterator(iterator, effectId, meta, cb) {
-    proc(iterator, taskContext, effectId, meta, env, cb)
+    proc(env, iterator, taskContext, effectId, meta, cb)
   }
 
-  function runTakeEffect({ channel = env.channel, pattern, maybe }, cb) {
+  function runTakeEffect({ channel = env.stdChannel, pattern, maybe }, cb) {
     const takeCb = input => {
       if (input instanceof Error) {
         cb(input, true)
@@ -521,7 +521,7 @@ export default function proc(iterator, parentContext, parentEffectId, meta, env,
     const meta = getIteratorMetaInfo(taskIterator, fn)
     try {
       suspend()
-      const task = proc(taskIterator, taskContext, effectId, meta, env, detached ? null : noop)
+      const task = proc(env, taskIterator, taskContext, effectId, meta, detached ? null : noop)
 
       if (detached) {
         cb(task)
@@ -667,12 +667,12 @@ export default function proc(iterator, parentContext, parentEffectId, meta, env,
 
     const taker = action => {
       if (!isEnd(action)) {
-        env.channel.take(taker, match)
+        env.stdChannel.take(taker, match)
       }
       chan.put(action)
     }
 
-    env.channel.take(taker, match)
+    env.stdChannel.take(taker, match)
     cb(chan)
   }
 

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -2,7 +2,6 @@ import { CANCEL, TERMINATE, TASK, TASK_CANCEL, SELF_CANCELLATION } from './symbo
 import {
   noop,
   is,
-  log as _log,
   check,
   deferred,
   uid as nextEffectId,
@@ -150,15 +149,6 @@ function createTaskIterator({ context, fn, args }) {
 }
 
 export default function proc(iterator, parentContext = {}, env, parentEffectId = 0, meta, cont) {
-  const log = env.logger || _log
-
-  const logError = err => {
-    log('error', err)
-    if (err && err.sagaStack) {
-      log('error', err.sagaStack)
-    }
-  }
-
   const taskContext = Object.create(parentContext)
 
   let crashedEffect = null
@@ -281,7 +271,7 @@ export default function proc(iterator, parentContext = {}, env, parentEffectId =
       }
     } catch (error) {
       if (mainTask._isCancelled) {
-        logError(error)
+        env.logError(error)
       }
       mainTask._isRunning = false
       mainTask.cont(error, true)
@@ -311,7 +301,7 @@ export default function proc(iterator, parentContext = {}, env, parentEffectId =
           env.onError(result)
         } else {
           // TODO: could we skip this when _deferredEnd is attached?
-          logError(result)
+          env.logError(result)
         }
       }
       task._error = result
@@ -416,7 +406,7 @@ export default function proc(iterator, parentContext = {}, env, parentEffectId =
       try {
         currCb.cancel()
       } catch (err) {
-        logError(err)
+        env.logError(err)
       }
       currCb.cancel = noop // defensive measure
 

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -47,6 +47,12 @@ export function runSaga(options, saga, ...args) {
     effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
   }
 
+  if (process.env.NODE_ENV === 'development') {
+    if (is.notUndef(onError)) {
+      check(onError, is.func, 'onError must be a function')
+    }
+  }
+
   const log = logger || _log
   const logError = err => {
     log('error', err)
@@ -58,7 +64,7 @@ export function runSaga(options, saga, ...args) {
   const middleware = effectMiddlewares && compose(...effectMiddlewares)
 
   const env = {
-    channel,
+    stdChannel: channel,
     dispatch: wrapSagaDispatch(dispatch),
     getState,
     sagaMonitor,
@@ -67,7 +73,7 @@ export function runSaga(options, saga, ...args) {
     middleware,
   }
 
-  const task = proc(iterator, context, effectId, getMetaInfo(saga), env, null)
+  const task = proc(env, iterator, context, effectId, getMetaInfo(saga), null)
 
   if (sagaMonitor) {
     sagaMonitor.effectResolved(effectId, task)

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -49,16 +49,17 @@ export function runSaga(options, saga, ...args) {
 
   const middleware = effectMiddlewares && compose(...effectMiddlewares)
 
-  const task = proc(
-    iterator,
+  const env = {
     channel,
-    wrapSagaDispatch(dispatch),
+    dispatch: wrapSagaDispatch(dispatch),
     getState,
-    context,
-    { sagaMonitor, logger, onError, middleware },
-    effectId,
-    getMetaInfo(saga),
-  )
+    sagaMonitor,
+    logger,
+    onError,
+    middleware,
+  }
+
+  const task = proc(iterator, context, env, effectId, getMetaInfo(saga))
 
   if (sagaMonitor) {
     sagaMonitor.effectResolved(effectId, task)

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -62,6 +62,16 @@ export function runSaga(options, saga, ...args) {
   }
 
   const middleware = effectMiddlewares && compose(...effectMiddlewares)
+  const finalizeRunEffect = runEffect => {
+    if (is.func(middleware)) {
+      return function finalRunEffect(effect, effectId, currCb) {
+        const plainRunEffect = eff => runEffect(eff, effectId, currCb)
+        return middleware(plainRunEffect)(effect)
+      }
+    } else {
+      return runEffect
+    }
+  }
 
   const env = {
     stdChannel: channel,
@@ -70,7 +80,7 @@ export function runSaga(options, saga, ...args) {
     sagaMonitor,
     logError,
     onError,
-    middleware,
+    finalizeRunEffect,
   }
 
   const task = proc(env, iterator, context, effectId, getMetaInfo(saga), null)

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -21,7 +21,7 @@ export function runSaga(options, saga, ...args) {
     channel = stdChannel(),
     dispatch,
     getState,
-    context,
+    context = {},
     sagaMonitor,
     logger,
     effectMiddlewares,
@@ -67,7 +67,7 @@ export function runSaga(options, saga, ...args) {
     middleware,
   }
 
-  const task = proc(iterator, context, env, effectId, getMetaInfo(saga))
+  const task = proc(iterator, context, effectId, getMetaInfo(saga), env, null)
 
   if (sagaMonitor) {
     sagaMonitor.effectResolved(effectId, task)

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,5 +1,5 @@
 import { compose } from 'redux'
-import { is, check, uid as nextSagaId, wrapSagaDispatch, noop } from './utils'
+import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
 
@@ -47,6 +47,14 @@ export function runSaga(options, saga, ...args) {
     effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
   }
 
+  const log = logger || _log
+  const logError = err => {
+    log('error', err)
+    if (err && err.sagaStack) {
+      log('error', err.sagaStack)
+    }
+  }
+
   const middleware = effectMiddlewares && compose(...effectMiddlewares)
 
   const env = {
@@ -54,7 +62,7 @@ export function runSaga(options, saga, ...args) {
     dispatch: wrapSagaDispatch(dispatch),
     getState,
     sagaMonitor,
-    logger,
+    logError,
     onError,
     middleware,
   }

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -109,8 +109,8 @@ export function delay(ms, val = true) {
 
 export function createMockTask() {
   let _isRunning = true
-  let _result = undefined
-  let _error = undefined
+  let _result
+  let _error
 
   return {
     [TASK]: true,

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -108,18 +108,19 @@ export function delay(ms, val = true) {
 }
 
 export function createMockTask() {
-  let running = true
-  let result, error
+  let _isRunning = true
+  let _result = undefined
+  let _error = undefined
 
   return {
     [TASK]: true,
-    isRunning: () => running,
-    result: () => result,
-    error: () => error,
+    isRunning: () => _isRunning,
+    result: () => _result,
+    error: () => _error,
 
-    setRunning: b => (running = b),
-    setResult: r => (result = r),
-    setError: e => (error = e),
+    setRunning: b => (_isRunning = b),
+    setResult: r => (_result = r),
+    setError: e => (_error = e),
   }
 }
 
@@ -162,9 +163,6 @@ export function deprecate(fn, deprecationWarning) {
     return fn(...args)
   }
 }
-
-export const updateIncentive = (deprecated, preferred) =>
-  `${deprecated} has been deprecated in favor of ${preferred}, please update your code`
 
 export const internalErr = err =>
   new Error(


### PR DESCRIPTION
Currently, function `proc()` has too many parameters (9 parameters). However, after root saga starts, some parameters never changes. Most of the calls to `proc()` just pass them down to child sagas. These parameters includes:

 * stdChannel
 * dispatch
 * getState
 * options.sagaMonitor
 * options.logger
 * options.onError
 * options.middleware

These parameter could be thought as **saga running environments**. In this PR I pack them into a single object called `env`. Other `proc()` parameters are task-specific, that means different calls to `proc()` would pass different values to these parameters.

Running sagas can read from the `env` to complete specific tasks, for example, logging an unhandled error. Running sagas should treat the `env` read-only and should not mutate `env`.

IMHO, introducing `env` will bring the following benefits:

* reduce the number of parameters of proc()
* better distinction between **Running Environments** and **Task Specific Parameters**
* Like [this post](https://github.com/redux-saga/redux-saga/pull/1263#discussion_r150841895) says, we may let the user to pre-process the `env` object before root-saga starts. Maybe users could inject custom effect-types and effect-runners by setting something like `env.runCustomEffects(...)`, and in `proc()` when we meet effects with unknown type, we use `env.runCustomEffects(...)` to run the effect. Anyway, introducing `env` would make it easier to extend redux-saga.