### PR TITLE
internal: Use env.finalizeRunEffect to simplify the implementation of digestEffect.

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -150,6 +150,7 @@ function createTaskIterator({ context, fn, args }) {
 
 export default function proc(iterator, parentContext, parentEffectId, meta, env, cont) {
   const taskContext = Object.create(parentContext)
+  const finalRunEffect = env.finalizeRunEffect(runEffect)
 
   let crashedEffect = null
   const cancelledDueToErrorTasks = []
@@ -413,16 +414,7 @@ export default function proc(iterator, parentContext, parentEffectId, meta, env,
       env.sagaMonitor && env.sagaMonitor.effectCancelled(effectId)
     }
 
-    // if one can find a way to decouple runEffect from closure variables
-    // so it could be the call to it could be referentially transparent
-    // this potentially could be simplified, finalRunEffect created beforehand
-    // and this part of the code wouldnt have to know about middleware stuff
-    if (is.func(env.middleware)) {
-      env.middleware(eff => runEffect(eff, effectId, currCb))(effect)
-      return
-    }
-
-    runEffect(effect, effectId, currCb)
+    finalRunEffect(effect, effectId, currCb)
   }
 
   function resolvePromise(promise, cb) {

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -56,6 +56,16 @@ export function runSaga(options, saga, ...args) {
   }
 
   const middleware = effectMiddlewares && compose(...effectMiddlewares)
+  const finalizeRunEffect = runEffect => {
+    if (is.func(middleware)) {
+      return function finalRunEffect(effect, effectId, currCb) {
+        const plainRunEffect = eff => runEffect(eff, effectId, currCb)
+        return middleware(plainRunEffect)(effect)
+      }
+    } else {
+      return runEffect
+    }
+  }
 
   const env = {
     channel,
@@ -64,7 +74,7 @@ export function runSaga(options, saga, ...args) {
     sagaMonitor,
     logError,
     onError,
-    middleware,
+    finalizeRunEffect,
   }
 
   const task = proc(iterator, context, effectId, getMetaInfo(saga), env, null)


### PR DESCRIPTION
This PR is based on #1479. If we introduce the `env`, then we can use `env.finalizeRunEffect` which converts runEffect to finalRunEffect [as the lines commented](https://github.com/redux-saga/redux-saga/blob/b956a0913028ffcc486c830290012c6ec9ff751d/packages/core/src/internal/proc.js#L433-L436). 

This PR remove passing `middleware` to `proc()`, since the running saga now depends `env.finalizeRunEffect` instead of `middleware`. This simplifies the implementation of `digestEffect`.

`env.finalizeRunEffect` could be think as an environment function, because it is determined before the root saga starts and never changes once created.

I think it is a good use case of `env`. Maybe we could do more enhancement using `env` afterwards. 
How do you think?