### PR TITLE
internal: using env.runCustomEffects to separate implementations of effect runners

### DIFF
--- a/packages/core/src/internal/common-effect-middlewares.js
+++ b/packages/core/src/internal/common-effect-middlewares.js
@@ -4,10 +4,14 @@ import { isEnd } from './channel'
 
 export const shouldComplete = res => isEnd(res) || shouldTerminate(res) || shouldCancel(res)
 
-export function makeSelectEffectMiddleware(getState) {
+export function createSelectEffectMiddleware(getState) {
   return next => arg => {
     if (arg.type !== effectTypes.SELECT) {
       return next(arg)
+    }
+    if (is.undef(getState)) {
+      arg.cb(new Error(`${effectTypes.SELECT} effect is only available when getState is defined`), true)
+      return
     }
     const { payload, cb } = arg
     const { selector, args } = payload

--- a/packages/core/src/internal/common-effect-middlewares.js
+++ b/packages/core/src/internal/common-effect-middlewares.js
@@ -1,0 +1,124 @@
+import { array, is, noop, shouldCancel, shouldTerminate } from './utils'
+import * as effectTypes from './effectTypes'
+import { isEnd } from './channel'
+
+export const shouldComplete = res => isEnd(res) || shouldTerminate(res) || shouldCancel(res)
+
+export function makeSelectEffectMiddleware(getState) {
+  return next => arg => {
+    if (arg.type !== effectTypes.SELECT) {
+      return next(arg)
+    }
+    const { payload, cb } = arg
+    const { selector, args } = payload
+    try {
+      const state = selector(getState(), ...args)
+      cb(state)
+    } catch (error) {
+      cb(error, true)
+    }
+  }
+}
+
+export function allEffectMiddleware(next) {
+  return arg => {
+    if (arg.type !== effectTypes.ALL) {
+      return next(arg)
+    }
+
+    const { payload: effects, cb, digestEffect, effectId } = arg
+    const keys = Object.keys(effects)
+
+    if (!keys.length) {
+      cb(is.array(effects) ? [] : {})
+      return
+    }
+
+    let completedCount = 0
+    let completed
+    const results = {}
+    const childCbs = {}
+
+    function checkEffectEnd() {
+      if (completedCount === keys.length) {
+        completed = true
+        cb(is.array(effects) ? array.from({ ...results, length: keys.length }) : results)
+      }
+    }
+
+    keys.forEach(key => {
+      const chCbAtKey = (res, isErr) => {
+        if (completed) {
+          return
+        }
+        if (isErr || shouldComplete(res)) {
+          cb.cancel()
+          cb(res, isErr)
+        } else {
+          results[key] = res
+          completedCount++
+          checkEffectEnd()
+        }
+      }
+      chCbAtKey.cancel = noop
+      childCbs[key] = chCbAtKey
+    })
+
+    cb.cancel = () => {
+      if (!completed) {
+        completed = true
+        keys.forEach(key => childCbs[key].cancel())
+      }
+    }
+
+    keys.forEach(key => digestEffect(effects[key], effectId, key, childCbs[key]))
+  }
+}
+
+export function raceEffectMiddleware(next) {
+  return arg => {
+    if (arg.type !== effectTypes.RACE) {
+      return next(arg)
+    }
+
+    const { payload: effects, cb, digestEffect, effectId } = arg
+    let completed
+    const keys = Object.keys(effects)
+    const childCbs = {}
+
+    keys.forEach(key => {
+      const chCbAtKey = (res, isErr) => {
+        if (completed) {
+          return
+        }
+
+        if (isErr) {
+          // Race Auto cancellation
+          cb.cancel()
+          cb(res, true)
+        } else if (!shouldComplete(res)) {
+          cb.cancel()
+          completed = true
+          const response = { [key]: res }
+          cb(is.array(effects) ? array.from({ ...response, length: keys.length }) : response)
+        }
+      }
+      chCbAtKey.cancel = noop
+      childCbs[key] = chCbAtKey
+    })
+
+    cb.cancel = () => {
+      // prevents unnecessary cancellation
+      if (!completed) {
+        completed = true
+        keys.forEach(key => childCbs[key].cancel())
+      }
+    }
+    keys.forEach(key => {
+      if (completed) {
+        return
+      }
+      digestEffect(effects[key], effectId, key, childCbs[key])
+    })
+  }
+}

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -2,13 +2,13 @@ import { compose } from 'redux'
 import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
-import { allEffectMiddleware, raceEffectMiddleware, makeSelectEffectMiddleware } from './common-effect-middlewares'
+import { allEffectMiddleware, raceEffectMiddleware, createSelectEffectMiddleware } from './common-effect-middlewares'
 
 const RUN_SAGA_SIGNATURE = 'runSaga(options, saga, ...args)'
 const NON_GENERATOR_ERR = `${RUN_SAGA_SIGNATURE}: saga argument must be a Generator function!`
 
 function defaultRunCustomEffect({ type, cb }) {
-  cb(new Error(`${type} is not a supported effect type`))
+  cb(new Error(`${type} is not a supported effect type`), true)
 }
 
 export function runSaga(options, saga, ...args) {
@@ -78,13 +78,12 @@ export function runSaga(options, saga, ...args) {
     }
   }
 
-  const customEffectMiddlewares = [allEffectMiddleware, raceEffectMiddleware]
   if (is.notUndef(getState)) {
     if (process.env.NODE_ENV === 'development') {
       check(getState, is.func, 'getState must be a function')
     }
-    customEffectMiddlewares.push(makeSelectEffectMiddleware(getState))
   }
+  const customEffectMiddlewares = [allEffectMiddleware, raceEffectMiddleware, createSelectEffectMiddleware(getState)]
   const runCustomEffect = compose(...customEffectMiddlewares)(defaultRunCustomEffect)
 
   const env = {

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -1,10 +1,13 @@
-import { CANCEL, MULTICAST, SAGA_ACTION, TASK } from './symbols'
+import { CANCEL, MULTICAST, SAGA_ACTION, TASK, TASK_CANCEL, TERMINATE } from './symbols'
 
 export const konst = v => () => v
 export const kTrue = konst(true)
 export const kFalse = konst(false)
 export const noop = () => {}
 export const identity = v => v
+
+export const shouldTerminate = res => res === TERMINATE
+export const shouldCancel = res => res === TASK_CANCEL
 
 export function check(value, predicate, error) {
   if (!predicate(value)) {


### PR DESCRIPTION
**EXPERIMENTAL** implementation of `env.runCustomEffects`. ~~This PR is based on #1477. Implementation of `env.runCustomEffects` is implemented in [this commit](https://github.com/redux-saga/redux-saga/pull/1488/commits/50a86d1fbaff04a5e264a37dfe099bdb3e02157e), other 3 commits are from the base PR.~~

In this PR, I add `runCustomEffects` to `env`. Every time `proc#runEffect` cannot find a core effect-runner for an effect, it will use `env.runCustomEffects` to run this effect. This allows us to define customized effect runners when constructing `env` in `runSaga()`. I adopt a similar way with `options.effectMiddlewares` that composes redux-like middlewares to enhance the `defaultRunCustomEffect`.  

I move the implementations of all/race/select effect runners from **proc.js** into **common-effect-middlewares.js**. And select effect runner is only defined when `options.getState` is a function.

What's passed to  `env.runCustomEffects`  should be carefully considered. Currently runCustomEffects is only used internally, so I passed `type, payload, env, currCb, effectId, digestEffect, taskContext` without in-depth consideration.

How do think about these changes? This experimental PR handles with `all / race / select`. Ideally, channel-related effect types (put / take / flush / actionChannel) could be handled in the same way.