### PR TITLE
fix import delay in docs

### DIFF
--- a/docs/advanced/ForkModel.md
+++ b/docs/advanced/ForkModel.md
@@ -18,7 +18,8 @@ Attached forks remain attached to their parent by the following rules
 For example say we have the following
 
 ```js
-import { fork, call, put, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { fork, call, put } from 'redux-saga/effects'
 import api from './somewhere/api' // app specific
 import { receiveData } from './somewhere/actions' // app specific
 

--- a/docs/advanced/RacingEffects.md
+++ b/docs/advanced/RacingEffects.md
@@ -8,7 +8,8 @@ The following sample shows a task that triggers a remote fetch request, and cons
 1 second timeout.
 
 ```javascript
-import { race, call, put, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { race, call, put } from 'redux-saga/effects'
 
 function* fetchPostsWithTimeout() {
   const {posts, timeout} = yield race({

--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -9,7 +9,8 @@ To see how it works, let's consider a basic example: A background sync which can
 The task will execute continually until a `STOP_BACKGROUND_SYNC` action is triggered. Then we cancel the background task and wait again for the next `START_BACKGROUND_SYNC` action.
 
 ```javascript
-import { take, put, call, fork, cancel, cancelled, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { take, put, call, fork, cancel, cancelled } from 'redux-saga/effects'
 import { someApi, actions } from 'somewhere'
 
 function* bgSync() {

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -24,7 +24,8 @@ To debounce a sequence, put the built-in `delay` helper in the forked task:
 
 ```javascript
 
-import { call, cancel, fork, take, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { call, cancel, fork, take } from 'redux-saga/effects'
 
 function* handleInput(input) {
   // debounce by 500ms
@@ -50,7 +51,8 @@ Example above could be rewritten with redux-saga `takeLatest` helper:
 
 ```javascript
 
-import { call, takeLatest, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { call, takeLatest } from 'redux-saga/effects'
 
 function* handleInput({ input }) {
   // debounce by 500ms
@@ -70,7 +72,8 @@ To retry a XHR call for a specific amount of times, use a for loop with a delay:
 
 ```javascript
 
-import { call, put, take, delay } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { call, put, take } from 'redux-saga/effects'
 
 function* updateApi(data) {
   for(let i = 0; i < 5; i++) {


### PR DESCRIPTION
there are mistake in several docs with `delay` util importing
```javascript
import { delay } from 'redux-saga/effects'
```

becouse `redux-saga/effects` does not exports `delay`, but `redux-saga` does itself.
So the right import line is:
```javascript
import { delay } from 'redux-saga'
```

Implement this change for every doc where occurs