### PR TITLE
Liftable channels

### DIFF
--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -51,7 +51,7 @@ export function put(channel, action) {
   }
   if (is.undef(action)) {
     action = channel
-    channel = null
+    channel = undefined
   }
   return makeEffect(effectTypes.PUT, { channel, action })
 }

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -4,7 +4,7 @@ import { identity } from './utils'
 import { runSaga } from './runSaga'
 
 export default function sagaMiddlewareFactory({ context = {}, ...options } = {}) {
-  const { sagaMonitor, logger, onError, effectMiddlewares } = options
+  const { sagaMonitor, logger, onError, effectMiddlewares, emitter } = options
 
   if (process.env.NODE_ENV === 'development') {
     if (is.notUndef(logger)) {
@@ -15,14 +15,13 @@ export default function sagaMiddlewareFactory({ context = {}, ...options } = {})
       check(onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
     }
 
-    if (is.notUndef(options.emitter)) {
-      check(options.emitter, is.func, 'options.emitter passed to the Saga middleware is not a function!')
+    if (is.notUndef(emitter)) {
+      check(emitter, is.func, 'options.emitter passed to the Saga middleware is not a function!')
     }
   }
 
   function sagaMiddleware({ getState, dispatch }) {
-    const channel = stdChannel()
-    channel.put = (options.emitter || identity)(channel.put)
+    const channel = stdChannel().lift(emitter || identity)
 
     sagaMiddleware.run = runSaga.bind(null, {
       context,

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -432,7 +432,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     proc(env, iterator, taskContext, effectId, meta, cb)
   }
 
-  function runTakeEffect({ channel = env.stdChannel, pattern, maybe }, cb) {
+  function runTakeEffect({ channel = env.channel, pattern, maybe }, cb) {
     const takeCb = input => {
       if (input instanceof Error) {
         cb(input, true)
@@ -453,7 +453,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     cb.cancel = takeCb.cancel
   }
 
-  function runPutEffect({ channel, action, resolve }, cb) {
+  function runPutEffect({ channel = env.channel, action, resolve }, cb) {
     /**
       Schedule the put in case another saga is holding a lock.
       The put will be executed atomically. ie nested puts will execute after
@@ -462,7 +462,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     asap(() => {
       let result
       try {
-        result = (channel ? channel.put : env.dispatch)(action)
+        result = channel.put(action)
       } catch (error) {
         cb(error, true)
         return
@@ -660,12 +660,12 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
     const taker = action => {
       if (!isEnd(action)) {
-        env.stdChannel.take(taker, match)
+        env.channel.take(taker, match)
       }
       chan.put(action)
     }
 
-    env.stdChannel.take(taker, match)
+    env.channel.take(taker, match)
     cb(chan)
   }
 

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,5 +1,5 @@
 import { compose } from 'redux'
-import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
+import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log, konst } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
 
@@ -73,9 +73,16 @@ export function runSaga(options, saga, ...args) {
     }
   }
 
+  let connectedChannel = channel
+  if (is.notUndef(dispatch)) {
+    if (process.env.NODE_ENV === 'development') {
+      check(dispatch, is.func, 'dispatch must be a function')
+    }
+    connectedChannel = channel.clone().lift(konst(wrapSagaDispatch(dispatch)))
+  }
+
   const env = {
-    stdChannel: channel,
-    dispatch: wrapSagaDispatch(dispatch),
+    channel: connectedChannel,
     getState,
     sagaMonitor,
     logError,

--- a/packages/core/test/runSaga.js
+++ b/packages/core/test/runSaga.js
@@ -1,5 +1,6 @@
 import test from 'tape'
 
+import mitt from 'mitt'
 import { runSaga, stdChannel } from '../src'
 import { fork, take, put, select, all } from '../src/effects'
 
@@ -17,7 +18,7 @@ function storeLike(reducer, state) {
   }
 }
 
-test('runSaga', assert => {
+test('runSaga with storeLike', assert => {
   assert.plan(1)
 
   let actual = []
@@ -62,6 +63,61 @@ test('runSaga', assert => {
     .toPromise()
     .then(() => {
       assert.deepEqual(actual, expected, 'runSaga must connect the provided iterator to the store, and run it')
+    })
+    .catch(err => assert.fail(err))
+})
+
+test('runSaga with emitter', assert => {
+  assert.plan(1)
+
+  let actual = []
+
+  const em = mitt()
+  let state = null
+  em.on('action', action => (state = action))
+
+  const channel = stdChannel().lift(put => {
+    em.on('action', put)
+    return input => em.emit('action', input)
+  })
+
+  const typeSelector = a => a.type
+  const task = runSaga({ channel, getState: () => state }, root)
+
+  function* root() {
+    yield all([fork(fnA), fork(fnB)])
+  }
+
+  function* fnA() {
+    actual.push(yield take('ACTION-1'))
+    actual.push(yield select(typeSelector))
+    actual.push(yield take('ACTION-2'))
+    actual.push(yield select(typeSelector))
+    yield put({ type: 'ACTION-3' })
+  }
+
+  function* fnB() {
+    actual.push(yield take('ACTION-3'))
+    actual.push(yield select(typeSelector))
+  }
+
+  Promise.resolve()
+    .then(() => em.emit('action', { type: 'ACTION-1' }))
+    .then(() => em.emit('action', { type: 'ACTION-2' }))
+
+  const expected = [
+    { type: 'ACTION-1' },
+    'ACTION-1',
+    { type: 'ACTION-2' },
+    'ACTION-2',
+    { type: 'ACTION-3' },
+    'ACTION-3',
+  ]
+
+  task
+    .toPromise()
+    .then(() => {
+      assert.deepEqual(actual, expected, 'runSaga must connect the provided iterator to the emitter, and run it')
     })
     .catch(err => assert.fail(err))
 })


### PR DESCRIPTION
It is just an experimental PR, feel free to reject it.

Currently, we are monkey-patching `channel.put` in several places. One is in **internal/channels.js**:

```javascript
export function stdChannel() {
  const chan = multicastChannel()
  const { put } = chan
  chan.put = input => {
    if (input[SAGA_ACTION]) {
      put(input)
      return
    }
    asap(() => put(input))
  }
  return chan
}
```

Another one is in **internal/middleware.js**:

```javascript
function sagaMiddleware({ getState, dispatch }) {
  const channel = stdChannel()
  channel.put = (options.emitter || identity)(channel.put)
  /* ...... */
}
```

In this PR, I add liftable channels to handle monkey-patching of `channel.put` . Calling `liftable(someMulticastChannel)` will return a liftable version that has a `lift(lifter)` method and a `clone()` method.

* `liftable.lift(lifter)`: lifter is a function that accepts the original *put*, and return a new *put*. The new *put* will replace the original one.
* `liftable.clone()`: lift method mutate channel object in-place. Calling `clone()` will return a cloned liftable, and lifts to the cloned will not affect the original.

I also lift the channel to a connected-channel using `wrapSagaDispatch(dispatch)` if `options.dispatch` is defined, so `env.dispatch` could be removed. 

How do you think about these changes to liftable channels?