### PR TITLE
Should finish race effect on END

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -613,12 +613,11 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
         if (completed) {
           return
         }
-
-        if (isErr) {
+        if (isErr || shouldComplete(res)) {
           // Race Auto cancellation
           cb.cancel()
-          cb(res, true)
-        } else if (!shouldComplete(res)) {
+          cb(res, isErr)
+        } else {
           cb.cancel()
           completed = true
           const response = { [key]: res }

--- a/packages/core/test/sagaHelpers/debounce.js
+++ b/packages/core/test/sagaHelpers/debounce.js
@@ -269,8 +269,8 @@ test('debounce: pattern END during race', assert => {
     .then(() => store.dispatch({type: 'ACTION'}))
     .then(() => delay(largeDelayMs))
     .then(() => {
+      assert.equal(called, 0, 'should interrupt race on END')
       assert.equal(task.isRunning(), false, 'should finish debounce task on END')
-      assert.equal(called, 1, 'should not call function on already finished channel')
       assert.end()
     })
     .catch(err => assert.fail(err))


### PR DESCRIPTION
a breaking change. 
race should be finished if any of effects resolved with END (by analogy with `all`)
https://github.com/redux-saga/redux-saga/issues/1362
https://github.com/redux-saga/redux-saga/issues/1354