### PR TITLE
Liftable stdChannel

### DIFF
--- a/packages/core/src/internal/channel.js
+++ b/packages/core/src/internal/channel.js
@@ -220,7 +220,7 @@ const scheduleSagaPut = put => input => {
 
 const wrapSagaDispatch = dispatch => action => dispatch(Object.defineProperty(action, SAGA_ACTION, { value: true }))
 
-function liftable(chan) {
+function multicastLiftable(chan) {
   chan.lift = fn => {
     if (process.env.NODE_ENV === 'development') {
       check(fn, is.func(fn), 'channel.lift(fn): fn must be a function')
@@ -234,7 +234,7 @@ function liftable(chan) {
 
   chan._clone = () => {
     const { put, take, close } = chan
-    return liftable({ [MULTICAST]: true, put, take, close })
+    return multicastLiftable({ [MULTICAST]: true, put, take, close })
   }
 
   chan._connect = dispatch => chan._clone().lift(() => wrapSagaDispatch(dispatch))
@@ -243,5 +243,5 @@ function liftable(chan) {
 }
 
 export function stdChannel() {
-  return liftable(multicastChannel()).lift(scheduleSagaPut)
+  return multicastLiftable(multicastChannel()).lift(scheduleSagaPut)
 }

--- a/packages/core/src/internal/channel.js
+++ b/packages/core/src/internal/channel.js
@@ -210,15 +210,38 @@ export function multicastChannel() {
   }
 }
 
-export function stdChannel() {
-  const chan = multicastChannel()
-  const { put } = chan
-  chan.put = input => {
-    if (input[SAGA_ACTION]) {
-      put(input)
-      return
-    }
+const scheduleSagaPut = put => input => {
+  if (input[SAGA_ACTION]) {
+    put(input)
+  } else {
     asap(() => put(input))
   }
+}
+
+const wrapSagaDispatch = dispatch => action => dispatch(Object.defineProperty(action, SAGA_ACTION, { value: true }))
+
+function liftable(chan) {
+  chan.lift = fn => {
+    if (process.env.NODE_ENV === 'development') {
+      check(fn, is.func(fn), 'channel.lift(fn): fn must be a function')
+    }
+    chan.put = fn(chan.put)
+    if (process.env.NODE_ENV === 'development') {
+      check(fn, is.func(chan.put), 'channel.lift(fn): fn must return a function')
+    }
+    return chan
+  }
+
+  chan._clone = () => {
+    const { put, take, close } = chan
+    return liftable({ [MULTICAST]: true, put, take, close })
+  }
+
+  chan._connect = dispatch => chan._clone().lift(() => wrapSagaDispatch(dispatch))
+
   return chan
+}
+
+export function stdChannel() {
+  return liftable(multicastChannel()).lift(scheduleSagaPut)
 }

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -51,7 +51,7 @@ export function put(channel, action) {
   }
   if (is.undef(action)) {
     action = channel
-    channel = null
+    channel = undefined
   }
   return makeEffect(effectTypes.PUT, { channel, action })
 }

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -1,10 +1,9 @@
 import { is, check, object, createSetContextWarning } from './utils'
 import { stdChannel } from './channel'
-import { identity } from './utils'
 import { runSaga } from './runSaga'
 
-export default function sagaMiddlewareFactory({ context = {}, ...options } = {}) {
-  const { sagaMonitor, logger, onError, effectMiddlewares } = options
+export default function sagaMiddlewareFactory(options = {}) {
+  const { context = {}, channel = stdChannel(), sagaMonitor, logger, onError, effectMiddlewares } = options
 
   if (process.env.NODE_ENV === 'development') {
     if (is.notUndef(logger)) {
@@ -15,15 +14,12 @@ export default function sagaMiddlewareFactory({ context = {}, ...options } = {})
       check(onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
     }
 
-    if (is.notUndef(options.emitter)) {
-      check(options.emitter, is.func, 'options.emitter passed to the Saga middleware is not a function!')
+    if (is.notUndef(channel)) {
+      check(channel, is.channel(channel), 'options.channel passed to the Saga middleware is not a channel')
     }
   }
 
   function sagaMiddleware({ getState, dispatch }) {
-    const channel = stdChannel()
-    channel.put = (options.emitter || identity)(channel.put)
-
     sagaMiddleware.run = runSaga.bind(null, {
       context,
       channel,

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -281,7 +281,6 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
   function end(result, isErr) {
     task._isRunning = false
-    // stdChannel.close()
 
     if (!isErr) {
       task._result = result
@@ -432,7 +431,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     proc(env, iterator, taskContext, effectId, meta, cb)
   }
 
-  function runTakeEffect({ channel = env.stdChannel, pattern, maybe }, cb) {
+  function runTakeEffect({ channel = env.channel, pattern, maybe }, cb) {
     const takeCb = input => {
       if (input instanceof Error) {
         cb(input, true)
@@ -453,7 +452,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     cb.cancel = takeCb.cancel
   }
 
-  function runPutEffect({ channel, action, resolve }, cb) {
+  function runPutEffect({ channel = env.channel, action, resolve }, cb) {
     /**
       Schedule the put in case another saga is holding a lock.
       The put will be executed atomically. ie nested puts will execute after
@@ -462,7 +461,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     asap(() => {
       let result
       try {
-        result = (channel ? channel.put : env.dispatch)(action)
+        result = channel.put(action)
       } catch (error) {
         cb(error, true)
         return
@@ -660,12 +659,12 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
     const taker = action => {
       if (!isEnd(action)) {
-        env.stdChannel.take(taker, match)
+        env.channel.take(taker, match)
       }
       chan.put(action)
     }
 
-    env.stdChannel.take(taker, match)
+    env.channel.take(taker, match)
     cb(chan)
   }
 

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,5 +1,5 @@
 import { compose } from 'redux'
-import { is, check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
+import { is, check, uid as nextSagaId, noop, log as _log } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
 
@@ -41,15 +41,19 @@ export function runSaga(options, saga, ...args) {
     sagaMonitor.effectTriggered({ effectId, root: true, parentEffectId: 0, effect: { root: true, saga, args } })
   }
 
-  if ((process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') && is.notUndef(effectMiddlewares)) {
-    const MIDDLEWARE_TYPE_ERROR = 'effectMiddlewares must be an array of functions'
-    check(effectMiddlewares, is.array, MIDDLEWARE_TYPE_ERROR)
-    effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
-  }
-
   if (process.env.NODE_ENV === 'development') {
+    if (is.notUndef(effectMiddlewares)) {
+      const MIDDLEWARE_TYPE_ERROR = 'effectMiddlewares must be an array of functions'
+      check(effectMiddlewares, is.array, MIDDLEWARE_TYPE_ERROR)
+      effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
+    }
+
     if (is.notUndef(onError)) {
       check(onError, is.func, 'onError must be a function')
+    }
+
+    if (is.notUndef(dispatch)) {
+      check(dispatch, is.func, 'dispatch must be a function')
     }
   }
 
@@ -74,8 +78,7 @@ export function runSaga(options, saga, ...args) {
   }
 
   const env = {
-    stdChannel: channel,
-    dispatch: wrapSagaDispatch(dispatch),
+    channel: channel._connect(dispatch || channel.put),
     getState,
     sagaMonitor,
     logError,

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -176,9 +176,6 @@ export const internalErr = err =>
 export const createSetContextWarning = (ctx, props) =>
   `${ctx ? ctx + '.' : ''}setContext(props): argument ${props} is not a plain object`
 
-export const wrapSagaDispatch = dispatch => action =>
-  dispatch(Object.defineProperty(action, SAGA_ACTION, { value: true }))
-
 export const cloneableGenerator = generatorFunc => (...args) => {
   const history = []
   const gen = generatorFunc(...args)

--- a/packages/core/test/runSaga.js
+++ b/packages/core/test/runSaga.js
@@ -1,5 +1,6 @@
 import test from 'tape'
 
+import mitt from 'mitt'
 import { runSaga, stdChannel } from '../src'
 import { fork, take, put, select, all } from '../src/effects'
 
@@ -17,7 +18,7 @@ function storeLike(reducer, state) {
   }
 }
 
-test('runSaga', assert => {
+test('runSaga with storeLike', assert => {
   assert.plan(1)
 
   let actual = []
@@ -62,6 +63,67 @@ test('runSaga', assert => {
     .toPromise()
     .then(() => {
       assert.deepEqual(actual, expected, 'runSaga must connect the provided iterator to the store, and run it')
+    })
+    .catch(err => assert.fail(err))
+})
+
+test('runSaga with emitter', assert => {
+  assert.plan(1)
+
+  let actual = []
+
+  const em = mitt()
+  let state = null
+  // Mimic a reducer
+  em.on('action', action => (state = action))
+
+  const channel = stdChannel()
+  em.on('action', action => channel.put(action))
+
+  const typeSelector = a => a.type
+  const task = runSaga(
+    {
+      channel,
+      dispatch: input => em.emit('action', input),
+      getState: () => state,
+    },
+    root,
+  )
+
+  function* root() {
+    yield all([fork(fnA), fork(fnB)])
+  }
+
+  function* fnA() {
+    actual.push(yield take('ACTION-1'))
+    actual.push(yield select(typeSelector))
+    actual.push(yield take('ACTION-2'))
+    actual.push(yield select(typeSelector))
+    yield put({ type: 'ACTION-3' })
+  }
+
+  function* fnB() {
+    actual.push(yield take('ACTION-3'))
+    actual.push(yield select(typeSelector))
+  }
+
+  Promise.resolve()
+    .then(() => em.emit('action', { type: 'ACTION-1' }))
+    .then(() => em.emit('action', { type: 'ACTION-2' }))
+
+  const expected = [
+    { type: 'ACTION-1' },
+    'ACTION-1',
+    { type: 'ACTION-2' },
+    'ACTION-2',
+    { type: 'ACTION-3' },
+    'ACTION-3',
+  ]
+
+  task
+    .toPromise()
+    .then(() => {
+      assert.deepEqual(actual, expected, 'runSaga must connect the provided iterator to the emitter, and run it')
     })
     .catch(err => assert.fail(err))
 })


### PR DESCRIPTION
In this PR, stdChannels become liftable. A liftable channel has three extra methods:

* `liftable.lift(lifter)`: lifter is a function that accepts the original put, and return a new put. The new put will replace the original put of the channel. Method `lift` is used to handle monkey-patching of `channel.put`.
* `liftable._clone()`: `lift(fn)` mutates channel object in-place. Calling ` _clone()` will return a cloned liftable, and lifts to the cloned will not affect the original.
* `liftable._connect(dispatch)`: connect channel to external I/O. This method return a connected-channel. `dispatch` will be used as **the put handler** for the connected-channel.

`env.dispatch` is removed in this PR, and all input/output of running saga is done via  `env.channel`. This makes sagas a little purer (requires less knowledge about the outer world).

## Public changes:

* stdChannel has a new public method `lift`. Users could use this method to lift/enhance a stdChannel.

* `options.emitter` of `sagaMiddlewareFactory` is removed. Instead, `options.channel` is added, users could create a stdChannel and lift it with the emitter to achieve the same goal of the old `options.emitter`. This make `sagaMiddlewareFactory()` and `runSaga()` more consistent in options: `runSaga#options` only has two more fields (dispatch / getState) than `sagaMiddlewareFactory#options`.