### PR TITLE
Move prettier config to .prettierrc.json

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,6 @@
 {
   "packages/*/{src,test}/**/*!(expected).js": [
-    "prettier --print-width=120 --single-quote --no-semi --trailing-comma=all --write",
+    "prettier --write",
     "eslint --fix",
     "git add"
   ]

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "all"
+}


### PR DESCRIPTION
Move prettier config to root package.json. With better integration with WebStorm and VSCode, we can use prettier to format the code without running lint-staged.