### PR TITLE
EXPERIMENTAL Introduce env.effectRunnerMap and support for custom effects

### DIFF
--- a/packages/core/src/internal/coreEffectRunners/actionChannel.js
+++ b/packages/core/src/internal/coreEffectRunners/actionChannel.js
@@ -1,0 +1,18 @@
+import { channel, isEnd } from '../channel'
+import matcher from '../matcher'
+
+export default function actionChannel(env, { pattern, buffer }, cb) {
+  // TODO: rethink how END is handled
+  const chan = channel(buffer)
+  const match = matcher(pattern)
+
+  const taker = action => {
+    if (!isEnd(action)) {
+      env.stdChannel.take(taker, match)
+    }
+    chan.put(action)
+  }
+
+  env.stdChannel.take(taker, match)
+  cb(chan)
+}

--- a/packages/core/src/internal/coreEffectRunners/all.js
+++ b/packages/core/src/internal/coreEffectRunners/all.js
@@ -1,0 +1,49 @@
+import { array, is, noop, shouldComplete } from '../utils'
+
+export default function all(env, effects, cb, { effectId, digestEffect }) {
+  const keys = Object.keys(effects)
+
+  if (!keys.length) {
+    cb(is.array(effects) ? [] : {})
+    return
+  }
+
+  let completedCount = 0
+  let completed
+  const results = {}
+  const childCbs = {}
+
+  function checkEffectEnd() {
+    if (completedCount === keys.length) {
+      completed = true
+      cb(is.array(effects) ? array.from({ ...results, length: keys.length }) : results)
+    }
+  }
+
+  keys.forEach(key => {
+    const chCbAtKey = (res, isErr) => {
+      if (completed) {
+        return
+      }
+      if (isErr || shouldComplete(res)) {
+        cb.cancel()
+        cb(res, isErr)
+      } else {
+        results[key] = res
+        completedCount++
+        checkEffectEnd()
+      }
+    }
+    chCbAtKey.cancel = noop
+    childCbs[key] = chCbAtKey
+  })
+
+  cb.cancel = () => {
+    if (!completed) {
+      completed = true
+      keys.forEach(key => childCbs[key].cancel())
+    }
+  }
+
+  keys.forEach(key => digestEffect(effects[key], effectId, key, childCbs[key]))
+}

--- a/packages/core/src/internal/coreEffectRunners/call.js
+++ b/packages/core/src/internal/coreEffectRunners/call.js
@@ -1,0 +1,21 @@
+import { is } from '../utils'
+import { getMetaInfo } from '../error-utils'
+
+export default function runCallEffect(env, { context, fn, args }, cb, { effectId, resolvePromise, resolveIterator }) {
+  let result
+  // catch synchronous failures; see #152
+  try {
+    result = fn.apply(context, args)
+  } catch (error) {
+    cb(error, true)
+    return
+  }
+
+  if (is.promise(result)) {
+    resolvePromise(result, cb)
+  } else if (is.iterator(result)) {
+    resolveIterator(result, effectId, getMetaInfo(fn), cb)
+  } else {
+    cb(result)
+  }
+}

--- a/packages/core/src/internal/coreEffectRunners/cancel.js
+++ b/packages/core/src/internal/coreEffectRunners/cancel.js
@@ -1,0 +1,12 @@
+import { SELF_CANCELLATION } from '../symbols'
+
+export default function cancel(env, taskToCancel, cb, { task }) {
+  if (taskToCancel === SELF_CANCELLATION) {
+    taskToCancel = task
+  }
+  if (taskToCancel.isRunning()) {
+    taskToCancel.cancel()
+  }
+  cb()
+  // cancel effects are non cancellables
+}

--- a/packages/core/src/internal/coreEffectRunners/cancelled.js
+++ b/packages/core/src/internal/coreEffectRunners/cancelled.js
@@ -1,0 +1,3 @@
+export default function runCancelledEffect(env, effectPayload, cb, { mainTask }) {
+  cb(Boolean(mainTask._isCancelled))
+}

--- a/packages/core/src/internal/coreEffectRunners/cancelled.js
+++ b/packages/core/src/internal/coreEffectRunners/cancelled.js
@@ -1,3 +1,3 @@
-export default function runCancelledEffect(env, effectPayload, cb, { mainTask }) {
-  cb(Boolean(mainTask._isCancelled))
+export default function runCancelledEffect(env, payload, cb, { mainTask }) {
+  cb(mainTask._isCancelled)
 }

--- a/packages/core/src/internal/coreEffectRunners/cps.js
+++ b/packages/core/src/internal/coreEffectRunners/cps.js
@@ -1,0 +1,17 @@
+import { is } from '../utils'
+
+export default function cps(env, { context, fn, args }, cb) {
+  // CPS (ie node style functions) can define their own cancellation logic
+  // by setting cancel field on the cb
+
+  // catch synchronous failures; see #152
+  try {
+    const cpsCb = (err, res) => (is.undef(err) ? cb(res) : cb(err, true))
+    fn.apply(context, args.concat(cpsCb))
+    if (cpsCb.cancel) {
+      cb.cancel = () => cpsCb.cancel()
+    }
+  } catch (error) {
+    cb(error, true)
+  }
+}

--- a/packages/core/src/internal/coreEffectRunners/flush.js
+++ b/packages/core/src/internal/coreEffectRunners/flush.js
@@ -1,0 +1,3 @@
+export default function flush(env, channel, cb) {
+  channel.flush(cb)
+}

--- a/packages/core/src/internal/coreEffectRunners/fork.js
+++ b/packages/core/src/internal/coreEffectRunners/fork.js
@@ -1,0 +1,73 @@
+import proc from '../proc'
+import { flush, suspend } from '../scheduler'
+import { is, makeIterator, noop } from '../utils'
+import { getMetaInfo } from '../error-utils'
+
+function createTaskIterator({ context, fn, args }) {
+  // catch synchronous failures; see #152 and #441
+  let result, error
+  try {
+    result = fn.apply(context, args)
+  } catch (err) {
+    error = err
+  }
+
+  // i.e. a generator function returns an iterator
+  if (is.iterator(result)) {
+    return result
+  }
+
+  // do not bubble up synchronous failures for detached forks
+  // instead create a failed task. See #152 and #441
+  return error
+    ? makeIterator(() => {
+        throw error
+      })
+    : makeIterator(
+        (function() {
+          let pc
+          const eff = { done: false, value: result }
+          const ret = value => ({ done: true, value })
+          return arg => {
+            if (!pc) {
+              pc = true
+              return eff
+            } else {
+              return ret(arg)
+            }
+          }
+        })(),
+      )
+}
+
+function getIteratorMetaInfo(iterator, fn) {
+  if (iterator.isSagaIterator) {
+    return { name: iterator.meta.name }
+  }
+  return getMetaInfo(fn)
+}
+
+export default function fork(env, { context, fn, args, detached }, cb, { effectId, taskContext, taskQueue }) {
+  const taskIterator = createTaskIterator({ context, fn, args })
+  const meta = getIteratorMetaInfo(taskIterator, fn)
+  try {
+    suspend()
+    const task = proc(env, taskIterator, taskContext, effectId, meta, detached ? null : noop)
+
+    if (detached) {
+      cb(task)
+    } else {
+      if (task._isRunning) {
+        taskQueue.addTask(task)
+        cb(task)
+      } else if (task._error) {
+        taskQueue.abort(task._error)
+      } else {
+        cb(task)
+      }
+    }
+  } finally {
+    flush()
+  }
+  // Fork effects are non cancellables
+}

--- a/packages/core/src/internal/coreEffectRunners/getContext.js
+++ b/packages/core/src/internal/coreEffectRunners/getContext.js
@@ -1,0 +1,3 @@
+export default function getContext(env, prop, cb, { taskContext }) {
+  cb(taskContext[prop])
+}

--- a/packages/core/src/internal/coreEffectRunners/index.js
+++ b/packages/core/src/internal/coreEffectRunners/index.js
@@ -1,0 +1,36 @@
+import * as effectTypes from '../effectTypes'
+import all from './all'
+import race from './race'
+import select from './select'
+import take from './take'
+import put from './put'
+import call from './call'
+import cps from './cps'
+import fork from './fork'
+import join from './join'
+import cancel from './cancel'
+import actionChannel from './actionChannel'
+import flush from './flush'
+import cancelled from './cancelled'
+import getContext from './getContext'
+import setContext from './setContext'
+
+const coreEffectRunnerMap = {
+  [effectTypes.TAKE]: take,
+  [effectTypes.PUT]: put,
+  [effectTypes.ALL]: all,
+  [effectTypes.RACE]: race,
+  [effectTypes.CALL]: call,
+  [effectTypes.CPS]: cps,
+  [effectTypes.FORK]: fork,
+  [effectTypes.JOIN]: join,
+  [effectTypes.CANCEL]: cancel,
+  [effectTypes.SELECT]: select,
+  [effectTypes.ACTION_CHANNEL]: actionChannel,
+  [effectTypes.CANCELLED]: cancelled,
+  [effectTypes.FLUSH]: flush,
+  [effectTypes.GET_CONTEXT]: getContext,
+  [effectTypes.SET_CONTEXT]: setContext,
+}
+
+export default coreEffectRunnerMap

--- a/packages/core/src/internal/coreEffectRunners/join.js
+++ b/packages/core/src/internal/coreEffectRunners/join.js
@@ -1,0 +1,11 @@
+import { remove } from '../utils'
+
+export default function join(env, t, cb, { task }) {
+  if (t.isRunning()) {
+    const joiner = { task, cb }
+    cb.cancel = () => remove(t.joiners, joiner)
+    t.joiners.push(joiner)
+  } else {
+    t.isAborted() ? cb(t.error(), true) : cb(t.result())
+  }
+}

--- a/packages/core/src/internal/coreEffectRunners/put.js
+++ b/packages/core/src/internal/coreEffectRunners/put.js
@@ -1,0 +1,26 @@
+import { asap } from '../scheduler'
+import { is } from '../utils'
+
+export default function put(env, { channel, action, resolve }, cb, { resolvePromise }) {
+  /**
+   Schedule the put in case another saga is holding a lock.
+   The put will be executed atomically. ie nested puts will execute after
+   this put has terminated.
+   **/
+  asap(() => {
+    let result
+    try {
+      result = (channel ? channel.put : env.dispatch)(action)
+    } catch (error) {
+      cb(error, true)
+      return
+    }
+
+    if (resolve && is.promise(result)) {
+      resolvePromise(result, cb)
+    } else {
+      cb(result)
+    }
+  })
+  // Put effects are non cancellables
+}

--- a/packages/core/src/internal/coreEffectRunners/race.js
+++ b/packages/core/src/internal/coreEffectRunners/race.js
@@ -1,0 +1,42 @@
+import { array, is, noop, shouldComplete } from '../utils'
+
+export default function race(env, effects, cb, { effectId, digestEffect }) {
+  let completed
+  const keys = Object.keys(effects)
+  const childCbs = {}
+
+  keys.forEach(key => {
+    const chCbAtKey = (res, isErr) => {
+      if (completed) {
+        return
+      }
+
+      if (isErr || shouldComplete(res)) {
+        // Race Auto cancellation
+        cb.cancel()
+        cb(res, isErr)
+      } else {
+        cb.cancel()
+        completed = true
+        const response = { [key]: res }
+        cb(is.array(effects) ? array.from({ ...response, length: keys.length }) : response)
+      }
+    }
+    chCbAtKey.cancel = noop
+    childCbs[key] = chCbAtKey
+  })
+
+  cb.cancel = () => {
+    // prevents unnecessary cancellation
+    if (!completed) {
+      completed = true
+      keys.forEach(key => childCbs[key].cancel())
+    }
+  }
+  keys.forEach(key => {
+    if (completed) {
+      return
+    }
+    digestEffect(effects[key], effectId, key, childCbs[key])
+  })
+}

--- a/packages/core/src/internal/coreEffectRunners/select.js
+++ b/packages/core/src/internal/coreEffectRunners/select.js
@@ -1,13 +1,12 @@
 import * as effectTypes from '../effectTypes'
 import { is } from '../utils'
 
-export default function select(env, payload, cb) {
+export default function select(env, { selector, args }, cb) {
   if (is.undef(env.getState)) {
     cb(new Error(`${effectTypes.SELECT} effect is only available when getState is defined`), true)
     return
   }
 
-  const { selector, args } = payload
   try {
     const state = selector(env.getState(), ...args)
     cb(state)

--- a/packages/core/src/internal/coreEffectRunners/select.js
+++ b/packages/core/src/internal/coreEffectRunners/select.js
@@ -1,0 +1,17 @@
+import * as effectTypes from '../effectTypes'
+import { is } from '../utils'
+
+export default function select(env, payload, cb) {
+  if (is.undef(env.getState)) {
+    cb(new Error(`${effectTypes.SELECT} effect is only available when getState is defined`), true)
+    return
+  }
+
+  const { selector, args } = payload
+  try {
+    const state = selector(env.getState(), ...args)
+    cb(state)
+  } catch (error) {
+    cb(error, true)
+  }
+}

--- a/packages/core/src/internal/coreEffectRunners/setContext.js
+++ b/packages/core/src/internal/coreEffectRunners/setContext.js
@@ -1,0 +1,6 @@
+import { object } from '../utils'
+
+export default function setContext(env, props, cb, { taskContext }) {
+  object.assign(taskContext, props)
+  cb()
+}

--- a/packages/core/src/internal/coreEffectRunners/take.js
+++ b/packages/core/src/internal/coreEffectRunners/take.js
@@ -1,0 +1,25 @@
+import { isEnd } from '../channel'
+import { is } from '../utils'
+import { TERMINATE } from '../symbols'
+import matcher from '../matcher'
+
+export default function take(env, { channel = env.stdChannel, pattern, maybe }, cb) {
+  const takeCb = input => {
+    if (input instanceof Error) {
+      cb(input, true)
+      return
+    }
+    if (isEnd(input) && !maybe) {
+      cb(TERMINATE)
+      return
+    }
+    cb(input)
+  }
+  try {
+    channel.take(takeCb, is.notUndef(pattern) ? matcher(pattern) : null)
+  } catch (err) {
+    cb(err, true)
+    return
+  }
+  cb.cancel = takeCb.cancel
+}

--- a/packages/core/src/internal/error-utils.js
+++ b/packages/core/src/internal/error-utils.js
@@ -8,6 +8,13 @@ export function getLocation(instrumented) {
   return instrumented[SAGA_LOCATION]
 }
 
+export function getMetaInfo(fn) {
+  return {
+    name: fn.name || 'anonymous',
+    location: getLocation(fn),
+  }
+}
+
 function effectLocationAsString(effect) {
   const location = getLocation(effect)
   if (location) {

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -1,10 +1,14 @@
-import { CANCEL, MULTICAST, SAGA_ACTION, TASK } from './symbols'
+import { CANCEL, MULTICAST, SAGA_ACTION, TASK, TASK_CANCEL, TERMINATE } from './symbols'
 
 export const konst = v => () => v
 export const kTrue = konst(true)
 export const kFalse = konst(false)
 export const noop = () => {}
 export const identity = v => v
+
+export const shouldTerminate = res => res === TERMINATE
+export const shouldCancel = res => res === TASK_CANCEL
+export const shouldComplete = res => shouldTerminate(res) || shouldCancel(res)
 
 export function check(value, predicate, error) {
   if (!predicate(value)) {


### PR DESCRIPTION
| Q                       | A                                           |
| ----------------------- | ------------------------------------------- |
| Fixed Issues?           | May fix #1238                               |
| Patch: Bug Fix?         | None                                        |
| Major: Breaking Change? | None                                        |
| Minor: New Feature?     | Support custom/user-defined effect          |
| Tests Added + Pass?     | Need to add new tests / Pass existing tests |
| Documentation           | Need to add documentation                   |
| Any Dependency Changes? |  None                                           |

**EXPERIMENTAL** implementation of `env.effectRunnerMap`. This PR is big since I separate implementations of core-effect-runners into different files. But the idea of this PR is rather simple.

In this PR, effect-runners have a unified function interface which can be seen in the new implementation of `runEffect` (the interface may need further discussion and refinement):

```javascript
function runEffect(effect, effectId, currCb) {
    if (is.promise(effect)) {
      resolvePromise(effect, currCb)
    } else if (is.iterator(effect)) {
      resolveIterator(effect, effectId, meta, currCb)
    } else if (effect && effect[IO]) {
      const effectRunningContext = {
        effectId,
        task,
        taskContext,
        mainTask,
        taskQueue,
        digestEffect,
        resolvePromise,
        resolveIterator,
      }

      const effectRunner = env.effectRunnerMap[effect.type]

      if (is.notUndef(effectRunner)) {
        // Unified effect-runner function interface
        effectRunner(env, effect.payload, currCb, effectRunningContext)
      } else {
        currCb(new Error(`${effect.type} is not a valid effect type`), true)
      }
    } else {
      // anything else returned as is
      currCb(effect)
    }
  }
```

`env.effectRunnerMap` is an object that maps effect-type to effect-runner. It is initialized in `runSaga()` by combining `coreEffectRunnerMap` and `options.customEffectRunnerMap`. 

`coreEffectRunnerMap` is the runner-map that contains all the existing core effect-runners. I've moved the core effect-runners into folder *src/internal/coreEffectRunners/*, one file per runner.

Users could provide `options.customEffectRunnerMap` to define custom effect types. But note that the core effect types have higher priority over custom effect types. 