### PR TITLE
Refactor join and cancel (#1515)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,9 +31,9 @@
   * [`spawn(fn, ...args)`](#spawnfn-args)
   * [`spawn([context, fn], ...args)`](#spawncontext-fn-args)
   * [`join(task)`](#jointask)
-  * [`join(...tasks)`](#jointasks)
+  * [`join([...tasks])`](#jointasks)
   * [`cancel(task)`](#canceltask)
-  * [`cancel(...tasks)`](#canceltasks)
+  * [`cancel([...tasks])`](#canceltasks)
   * [`cancel()`](#cancel)
   * [`select(selector, ...args)`](#selectselector-args)
   * [`actionChannel(pattern, [buffer])`](#actionchannelpattern-buffer)
@@ -530,7 +530,7 @@ of a previously forked task.
 task is cancelled, the cancellation will also propagate to the Saga executing the join
 effect. Similarly, any potential callers of those joiners will be cancelled as well.
 
-### `join(...tasks)`
+### `join([...tasks])`
 
 Creates an Effect description that instructs the middleware to wait for the results of previously forked tasks.
 
@@ -594,7 +594,7 @@ function* mySaga() {
 
 redux-saga will automatically cancel jqXHR objects using their `abort` method.
 
-### `cancel(...tasks)`
+### `cancel([...tasks])`
 
 Creates an Effect description that instructs the middleware to cancel previously forked tasks.
 

--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -336,7 +336,7 @@ export const fork: CallEffectFactory<ForkEffect>;
 export const spawn: CallEffectFactory<ForkEffect>;
 
 
-export type JoinEffectDescriptor = Task;
+export type JoinEffectDescriptor = Task | Task[];
 
 export interface JoinEffect {
   type: 'JOIN';
@@ -344,12 +344,11 @@ export interface JoinEffect {
 }
 
 export function join(task: Task): JoinEffect;
-export function join(task1: Task, task2: Task,
-                     ...tasks: Task[]): GenericAllEffect<JoinEffect>;
+export function join(tasks: Task[]): JoinEffect;
 
 
 type SELF_CANCELLATION = '@@redux-saga/SELF_CANCELLATION';
-export type CancelEffectDescriptor = Task | SELF_CANCELLATION;
+export type CancelEffectDescriptor = Task | Task[] | SELF_CANCELLATION;
 
 export interface CancelEffect {
   type: 'CANCEL';
@@ -358,7 +357,7 @@ export interface CancelEffect {
 
 export function cancel(): CancelEffect;
 export function cancel(task: Task): CancelEffect;
-export function cancel(...tasks: Task[]): GenericAllEffect<CancelEffect>;
+export function cancel(tasks: Task[]): CancelEffect;
 
 
 export interface SelectEffectDescriptor {

--- a/packages/core/src/internal/channel.js
+++ b/packages/core/src/internal/channel.js
@@ -40,11 +40,10 @@ export function channel(buffer = buffers.expanding()) {
     if (closed) {
       return
     }
-    if (!takers.length) {
+    if (takers.length === 0) {
       return buffer.put(input)
     }
-    const cb = takers[0]
-    takers.splice(0, 1)
+    const cb = takers.shift()
     cb(input)
   }
 

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -151,7 +151,7 @@ export function cancel(taskOrTasks) {
   if (process.env.NODE_ENV === 'development') {
     if (is.array(taskOrTasks)) {
       taskOrTasks.forEach(t => {
-        check(t, is.task, `join([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
+        check(t, is.task, `cancel([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
       })
     } else if (is.notUndef(taskOrTasks)) {
       check(taskOrTasks, is.task, `cancel(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -129,7 +129,6 @@ export function join(taskOrTasks) {
         check(t, is.task, `join([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
       })
     } else {
-      check(taskOrTasks, is.notUndef, 'join(task): argument task is undefined')
       check(taskOrTasks, is.task, `join(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)
     }
   }
@@ -141,7 +140,7 @@ const printCancelDeprecationWarning = once(() =>
   log('warn', '`cancel(...tasks)` is deprecated. Please use `cancel([...tasks])` to cancel multiple tasks.'),
 )
 
-export function cancel(taskOrTasks) {
+export function cancel(taskOrTasks = SELF_CANCELLATION) {
   if (arguments.length > 1) {
     if (process.env.NODE_ENV === 'development') {
       printCancelDeprecationWarning()
@@ -153,13 +152,12 @@ export function cancel(taskOrTasks) {
       taskOrTasks.forEach(t => {
         check(t, is.task, `cancel([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
       })
-    } else if (is.notUndef(taskOrTasks)) {
+    } else if (taskOrTasks !== SELF_CANCELLATION && is.notUndef(taskOrTasks)) {
       check(taskOrTasks, is.task, `cancel(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)
     }
-    // else taskOrTasks is undefined, which means self cancellation
   }
 
-  return makeEffect(effectTypes.CANCEL, taskOrTasks || SELF_CANCELLATION)
+  return makeEffect(effectTypes.CANCEL, taskOrTasks)
 }
 
 export function select(selector = identity, ...args) {

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -127,19 +127,19 @@ export function join(taskOrTasks) {
   return makeEffect(effectTypes.JOIN, taskOrTasks)
 }
 
-export function cancel(...tasks) {
-  if (tasks.length > 1) {
-    return all(tasks.map(t => cancel(t)))
+export function cancel(taskOrTasks) {
+  if (process.env.NODE_ENV === 'development') {
+    if (is.array(taskOrTasks)) {
+      taskOrTasks.forEach(t => {
+        check(t, is.task, `join([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
+      })
+    } else {
+      check(taskOrTasks, is.notUndef, 'cancel(task): argument task is undefined')
+      check(taskOrTasks, is.task, `cancel(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)
+    }
   }
 
-  const task = tasks[0]
-
-  if (process.env.NODE_ENV === 'development' && tasks.length === 1) {
-    check(task, is.notUndef, 'cancel(task): argument task is undefined')
-    check(task, is.task, `cancel(task): argument ${task} is not a valid Task object ${TEST_HINT}`)
-  }
-
-  return makeEffect(effectTypes.CANCEL, task || SELF_CANCELLATION)
+  return makeEffect(effectTypes.CANCEL, taskOrTasks || SELF_CANCELLATION)
 }
 
 export function select(selector = identity, ...args) {

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -1,5 +1,5 @@
 import { IO, SELF_CANCELLATION } from './symbols'
-import { delay as delayUtil, is, identity, check, createSetContextWarning } from './utils'
+import { log, once, array, delay as delayUtil, is, identity, check, createSetContextWarning } from './utils'
 import * as effectTypes from './effectTypes'
 
 const TEST_HINT =
@@ -112,7 +112,17 @@ export function spawn(fn, ...args) {
   return detach(fork(fn, ...args))
 }
 
+const printJoinDeprecationWarning = once(() =>
+  log('warn', '`join(...tasks)` is deprecated. Please use `join([...tasks])` to join multiple tasks.'),
+)
+
 export function join(taskOrTasks) {
+  if (arguments.length > 1) {
+    if (process.env.NODE_ENV === 'development') {
+      printJoinDeprecationWarning()
+    }
+    taskOrTasks = array.from(arguments)
+  }
   if (process.env.NODE_ENV === 'development') {
     if (is.array(taskOrTasks)) {
       taskOrTasks.forEach(t => {
@@ -127,7 +137,17 @@ export function join(taskOrTasks) {
   return makeEffect(effectTypes.JOIN, taskOrTasks)
 }
 
+const printCancelDeprecationWarning = once(() =>
+  log('warn', '`cancel(...tasks)` is deprecated. Please use `cancel([...tasks])` to cancel multiple tasks.'),
+)
+
 export function cancel(taskOrTasks) {
+  if (arguments.length > 1) {
+    if (process.env.NODE_ENV === 'development') {
+      printCancelDeprecationWarning()
+    }
+    taskOrTasks = array.from(arguments)
+  }
   if (process.env.NODE_ENV === 'development') {
     if (is.array(taskOrTasks)) {
       taskOrTasks.forEach(t => {

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -153,10 +153,10 @@ export function cancel(taskOrTasks) {
       taskOrTasks.forEach(t => {
         check(t, is.task, `join([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
       })
-    } else {
-      check(taskOrTasks, is.notUndef, 'cancel(task): argument task is undefined')
+    } else if (is.notUndef(taskOrTasks)) {
       check(taskOrTasks, is.task, `cancel(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)
     }
+    // else taskOrTasks is undefined, which means self cancellation
   }
 
   return makeEffect(effectTypes.CANCEL, taskOrTasks || SELF_CANCELLATION)

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -112,19 +112,19 @@ export function spawn(fn, ...args) {
   return detach(fork(fn, ...args))
 }
 
-export function join(...tasks) {
-  if (tasks.length > 1) {
-    return all(tasks.map(t => join(t)))
-  }
-
-  const task = tasks[0]
-
+export function join(taskOrTasks) {
   if (process.env.NODE_ENV === 'development') {
-    check(task, is.notUndef, 'join(task): argument task is undefined')
-    check(task, is.task, `join(task): argument ${task} is not a valid Task object ${TEST_HINT}`)
+    if (is.array(taskOrTasks)) {
+      taskOrTasks.forEach(t => {
+        check(t, is.task, `join([...tasks]): argument ${t} is not a valid Task object ${TEST_HINT}`)
+      })
+    } else {
+      check(taskOrTasks, is.notUndef, 'join(task): argument task is undefined')
+      check(taskOrTasks, is.task, `join(task): argument ${taskOrTasks} is not a valid Task object ${TEST_HINT}`)
+    }
   }
 
-  return makeEffect(effectTypes.JOIN, task)
+  return makeEffect(effectTypes.JOIN, taskOrTasks)
 }
 
 export function cancel(...tasks) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -566,28 +566,20 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
   function runCancelEffect(taskOrTasks, cb) {
     if (taskOrTasks === SELF_CANCELLATION) {
-      cancelSingleTask(task, cb)
+      cancelSingleTask(task)
     } else if (is.array(taskOrTasks)) {
-      if (taskOrTasks.length === 0) {
-        cb()
-        return
-      }
-
-      const childCallbacks = createAllStyleChildCallbacks(taskOrTasks, cb)
-      taskOrTasks.forEach((t, i) => {
-        cancelSingleTask(t, childCallbacks[i])
-      })
+      taskOrTasks.forEach(cancelSingleTask)
     } else {
-      cancelSingleTask(taskOrTasks, cb)
-    }
-  }
-
-  function cancelSingleTask(taskToCancel, cb) {
-    if (taskToCancel.isRunning()) {
-      taskToCancel.cancel()
+      cancelSingleTask(taskOrTasks)
     }
     cb()
     // cancel effects are non cancellables
+  }
+
+  function cancelSingleTask(taskToCancel) {
+    if (taskToCancel.isRunning()) {
+      taskToCancel.cancel()
+    }
   }
 
   function runAllEffect(effects, effectId, cb) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -537,7 +537,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
   function runJoinEffect(taskOrTasks, cb) {
     if (is.array(taskOrTasks)) {
       if (taskOrTasks.length === 0) {
-        cb()
+        cb([])
         return
       }
 

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -550,13 +550,17 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     }
   }
 
-  function joinSingleTask(task, cb) {
-    if (task.isRunning()) {
+  function joinSingleTask(taskToJoin, cb) {
+    if (taskToJoin.isRunning()) {
       const joiner = { task, cb }
-      cb.cancel = () => remove(task.joiners, joiner)
-      task.joiners.push(joiner)
+      cb.cancel = () => remove(taskToJoin.joiners, joiner)
+      taskToJoin.joiners.push(joiner)
     } else {
-      task.isAborted() ? cb(task.error(), true) : cb(task.result())
+      if (taskToJoin.isAborted()) {
+        cb(taskToJoin.error(), true)
+      } else {
+        cb(taskToJoin.result())
+      }
     }
   }
 

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -536,6 +536,11 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
   function runJoinEffect(taskOrTasks, cb) {
     if (is.array(taskOrTasks)) {
+      if (taskOrTasks.length === 0) {
+        cb()
+        return
+      }
+
       const childCallbacks = createAllStyleChildCallbacks(taskOrTasks, cb)
       taskOrTasks.forEach((t, i) => {
         joinSingleTask(t, childCallbacks[i])
@@ -555,10 +560,25 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     }
   }
 
-  function runCancelEffect(taskToCancel, cb) {
-    if (taskToCancel === SELF_CANCELLATION) {
-      taskToCancel = task
+  function runCancelEffect(taskOrTasks, cb) {
+    if (taskOrTasks === SELF_CANCELLATION) {
+      cancelSingleTask(task, cb)
+    } else if (is.array(taskOrTasks)) {
+      if (taskOrTasks.length === 0) {
+        cb()
+        return
+      }
+
+      const childCallbacks = createAllStyleChildCallbacks(taskOrTasks, cb)
+      taskOrTasks.forEach((t, i) => {
+        cancelSingleTask(t, childCallbacks[i])
+      })
+    } else {
+      cancelSingleTask(taskOrTasks, cb)
     }
+  }
+
+  function cancelSingleTask(taskToCancel, cb) {
     if (taskToCancel.isRunning()) {
       taskToCancel.cancel()
     }

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -203,6 +203,7 @@ export const shouldComplete = res => shouldTerminate(res) || shouldCancel(res)
 
 export function createAllStyleChildCallbacks(shape, parentCallback) {
   const keys = Object.keys(shape)
+  const totalCount = keys.length
 
   let completedCount = 0
   let completed
@@ -210,9 +211,13 @@ export function createAllStyleChildCallbacks(shape, parentCallback) {
   const childCallbacks = {}
 
   function checkEnd() {
-    if (completedCount === keys.length) {
+    if (completedCount === totalCount) {
       completed = true
-      parentCallback(is.array(shape) ? array.from({ ...results, length: keys.length }) : results)
+      if (is.array(shape)) {
+        parentCallback(array.from({ ...results, length: totalCount }))
+      } else {
+        parentCallback(results)
+      }
     }
   }
 

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -205,6 +205,10 @@ export function createAllStyleChildCallbacks(shape, parentCallback) {
   const keys = Object.keys(shape)
   const totalCount = keys.length
 
+  if (process.env.NODE_ENV === 'development') {
+    check(totalCount, c => c > 0, 'createAllStyleChildCallbacks: get an empty array or object')
+  }
+
   let completedCount = 0
   let completed
   const results = {}

--- a/packages/core/test/interpreter/cancellation.js
+++ b/packages/core/test/interpreter/cancellation.js
@@ -824,7 +824,7 @@ test('cancel should be able to cancel multiple tasks', assert => {
     const t1 = yield io.fork(worker, 0)
     const t2 = yield io.fork(worker, 1)
     const t3 = yield io.fork(worker, 2)
-    yield io.cancel(t1, t2, t3)
+    yield io.cancel([t1, t2, t3])
   }
 
   const task = middleware.run(genFn)

--- a/packages/core/test/interpreter/forkjoin.js
+++ b/packages/core/test/interpreter/forkjoin.js
@@ -582,7 +582,7 @@ test('joining multiple tasks', assert => {
     const task2 = yield io.fork(worker, 1)
     const task3 = yield io.fork(worker, 2)
 
-    actual = yield io.join(task1, task2, task3)
+    actual = yield io.join([task1, task2, task3])
   }
 
   const mainTask = middleware.run(genFn)

--- a/packages/core/test/typescript/effects.ts
+++ b/packages/core/test/typescript/effects.ts
@@ -520,6 +520,8 @@ function* testJoin(): SagaIterator {
   yield join({});
 
   yield join(task);
+  // typings:expect-error
+  yield join(task, task);
   yield join([task, task]);
   yield join([task, task, task]);
 
@@ -536,6 +538,8 @@ function* testCancel(): SagaIterator {
   yield cancel({});
 
   yield cancel(task);
+  // typings:expect-error
+  yield cancel(task, task);
   yield cancel([task, task]);
   yield cancel([task, task, task]);
 

--- a/packages/core/test/typescript/effects.ts
+++ b/packages/core/test/typescript/effects.ts
@@ -520,11 +520,11 @@ function* testJoin(): SagaIterator {
   yield join({});
 
   yield join(task);
-  yield join(task, task);
-  yield join(task, task, task);
+  yield join([task, task]);
+  yield join([task, task, task]);
 
   // typings:expect-error
-  yield join(task, task, {});
+  yield join([task, task, {}]);
 }
 
 function* testCancel(): SagaIterator {
@@ -536,15 +536,15 @@ function* testCancel(): SagaIterator {
   yield cancel({});
 
   yield cancel(task);
-  yield cancel(task, task);
-  yield cancel(task, task, task);
+  yield cancel([task, task]);
+  yield cancel([task, task, task]);
 
   const tasks: Task[] = [];
 
-  yield cancel(...tasks);
+  yield cancel(tasks);
 
   // typings:expect-error
-  yield cancel(task, task, {});
+  yield cancel([task, task, {}]);
 }
 
 function* testDetach(): SagaIterator {


### PR DESCRIPTION
| Q                       | A         |
| ----------------------- | --------- |
| Fixed Issues?           | #1515     |
| Patch: Bug Fix?         |           |
| Major: Breaking Change? | See below |
| Minor: New Feature?     |           |
| Tests Added + Pass?     | Passed    |
| Documentation           | Updated   |
| Any Dependency Changes? |           |

In this PR, I change the signatures of join/cancel from variadic arguments to a single array argument. This PR ensures that calling `cancel(...)` returns a cancel-effect (before it may return an all-effect), and ensures that calling `join(...)` returns a join-effect.

Deprecation warnings are added to make it easier to migrate to new API.  A small change in *internal/channel.js* is also included in this PR 😄 .