### PR TITLE
Convert stdChannel to an enhanceable version of multicast channel.

### DIFF
--- a/packages/core/__tests__/enhanceable-channel.js
+++ b/packages/core/__tests__/enhanceable-channel.js
@@ -1,0 +1,95 @@
+import { takeEvery } from '../src/internal/io-helpers'
+import { runSaga, stdChannel } from '../src'
+import { put } from '../src/effects'
+import mitt from 'mitt'
+
+test('enhance a channel with a custom emitter', () => {
+  const actual = []
+
+  const emitter = emit => action => {
+    if (action.type === 'batch') {
+      action.batch.forEach(emit)
+      return
+    }
+    emit(action)
+  }
+  const channel = stdChannel().enhancePut(emitter)
+  runSaga({ channel }, function*() {
+    yield takeEvery('*', ac => actual.push(ac.type))
+  })
+
+  channel.put({ type: 'a' })
+  channel.put({
+    type: 'batch',
+    batch: [{ type: 'b' }, { type: 'c' }, { type: 'd' }],
+  })
+  channel.put({ type: 'e' })
+
+  expect(actual).toEqual(['a', 'b', 'c', 'd', 'e'])
+})
+
+test('external IO: connect channel to an emitter', () => {
+  const emitterCollected = []
+  const takeEveryCollected = []
+
+  const mit = mitt()
+  const channel = stdChannel().enhancePut(oldPut => {
+    mit.on('action', ac => emitterCollected.push(ac.type))
+
+    // when the emitter gets an action, put it into the channel via the old-put
+    mit.on('action', oldPut)
+
+    // return a new-put to replace the old-put
+    return ac => mit.emit('action', ac)
+  })
+
+  runSaga({ channel }, function*() {
+    yield takeEvery('*', ac => takeEveryCollected.push(ac.type))
+    yield put({ type: 'FROM_PUT_EFFECT' })
+  })
+
+  channel.put({ type: 'FROM_CHANNEL_PUT' })
+  mit.emit('action', { type: 'FROM_EMITTER' })
+
+  const expected = ['FROM_PUT_EFFECT', 'FROM_CHANNEL_PUT', 'FROM_EMITTER']
+  expect(emitterCollected).toEqual(expected)
+  expect(takeEveryCollected).toEqual(expected)
+})
+
+class FakeSubject {
+  constructor() {
+    this.listeners = []
+  }
+
+  next(value) {
+    this.listeners.forEach(f => f(value))
+  }
+
+  subscribe(listener) {
+    this.listeners.push(listener)
+  }
+}
+
+test('external IO: connect channel to a RxJS Subject', () => {
+  const subjectCollected = []
+  const takeEveryCollected = []
+
+  const subject = new FakeSubject()
+  const channel = stdChannel().enhancePut(oldPut => {
+    subject.subscribe(oldPut)
+    subject.subscribe(ac => subjectCollected.push(ac.type))
+    return ac => subject.next(ac)
+  })
+
+  runSaga({ channel }, function* saga() {
+    yield takeEvery('*', ac => takeEveryCollected.push(ac.type))
+    yield put({ type: 'FROM_PUT_EFFECT' })
+  })
+
+  channel.put({ type: 'FROM_CHANNEL_PUT' })
+  subject.next({ type: 'FROM_SUBJECT_NEXT' })
+
+  const expected = ['FROM_PUT_EFFECT', 'FROM_CHANNEL_PUT', 'FROM_SUBJECT_NEXT']
+  expect(subjectCollected).toEqual(expected)
+  expect(takeEveryCollected).toEqual(expected)
+})

--- a/packages/core/__tests__/middleware.js
+++ b/packages/core/__tests__/middleware.js
@@ -1,7 +1,7 @@
-import { createStore, applyMiddleware } from 'redux'
+import { applyMiddleware, createStore } from 'redux'
 import sagaMiddleware from '../src'
 import * as is from '@redux-saga/is'
-import { takeEvery } from '../src/effects'
+
 test('middleware output', () => {
   const middleware = sagaMiddleware() // middleware factory must return a function to handle {getState, dispatch}
 
@@ -19,12 +19,14 @@ test('middleware output', () => {
 
   expect(actionHandler.length).toBe(1)
 })
+
 test("middleware's action handler output", () => {
   const action = {}
   const actionHandler = sagaMiddleware()({})(action => action) // action handler must return the result of the next argument
 
   expect(actionHandler(action)).toBe(action)
 })
+
 test('middleware.run', () => {
   let actual
 
@@ -49,6 +51,7 @@ test('middleware.run', () => {
 
   expect(actual).toEqual(expected)
 })
+
 test('middleware options', () => {
   try {
     sagaMiddleware({
@@ -75,49 +78,6 @@ test('middleware options', () => {
   middleware.run(saga) // `options.onError` is called appropriately
 
   expect(actual).toBe(expected)
-})
-test("middleware's custom emitter", () => {
-  const actual = []
-
-  function* saga() {
-    yield takeEvery('*', ac => actual.push(ac.type))
-  }
-
-  const middleware = sagaMiddleware({
-    emitter: emit => action => {
-      if (action.type === 'batch') {
-        action.batch.forEach(emit)
-        return
-      }
-
-      emit(action)
-    },
-  })
-  const store = createStore(() => {}, applyMiddleware(middleware))
-  middleware.run(saga)
-  store.dispatch({
-    type: 'a',
-  })
-  store.dispatch({
-    type: 'batch',
-    batch: [
-      {
-        type: 'b',
-      },
-      {
-        type: 'c',
-      },
-      {
-        type: 'd',
-      },
-    ],
-  })
-  store.dispatch({
-    type: 'e',
-  })
-  const expected = ['a', 'b', 'c', 'd', 'e'] // saga must be able to take actions emitted by middleware's custom emitter
-
-  expect(actual).toEqual(expected)
 })
 
 test('middleware.run saga arguments validation', () => {

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -52,7 +52,7 @@ export function put(channel, action) {
   }
   if (is.undef(action)) {
     action = channel
-    channel = null
+    channel = undefined
   }
   return makeEffect(effectTypes.PUT, { channel, action })
 }

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -1,11 +1,10 @@
 import * as is from '@redux-saga/is'
 import { check, assignWithSymbols, createSetContextWarning } from './utils'
 import { stdChannel } from './channel'
-import { identity } from './utils'
 import { runSaga } from './runSaga'
 
-export default function sagaMiddlewareFactory({ context = {}, ...options } = {}) {
-  const { sagaMonitor, logger, onError, effectMiddlewares } = options
+export default function sagaMiddlewareFactory(options = {}) {
+  const { context = {}, channel = stdChannel(), sagaMonitor, logger, onError, effectMiddlewares } = options
   let boundRunSaga
 
   if (process.env.NODE_ENV !== 'production') {
@@ -17,15 +16,12 @@ export default function sagaMiddlewareFactory({ context = {}, ...options } = {})
       check(onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
     }
 
-    if (is.notUndef(options.emitter)) {
-      check(options.emitter, is.func, 'options.emitter passed to the Saga middleware is not a function!')
+    if (is.notUndef(channel)) {
+      check(channel, is.channel, 'options.channel passed to the Saga middleware is not a channel')
     }
   }
 
   function sagaMiddleware({ getState, dispatch }) {
-    const channel = stdChannel()
-    channel.put = (options.emitter || identity)(channel.put)
-
     boundRunSaga = runSaga.bind(null, {
       context,
       channel,

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,6 +1,6 @@
 import * as is from '@redux-saga/is'
 import { compose } from 'redux'
-import { check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
+import { check, uid as nextSagaId, noop, log as _log } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
 
@@ -47,11 +47,13 @@ export function runSaga(options, saga, ...args) {
     const MIDDLEWARE_TYPE_ERROR = 'effectMiddlewares must be an array of functions'
     check(effectMiddlewares, is.array, MIDDLEWARE_TYPE_ERROR)
     effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
-  }
 
-  if (process.env.NODE_ENV !== 'production') {
     if (is.notUndef(onError)) {
       check(onError, is.func, 'onError must be a function')
+    }
+
+    if (is.notUndef(dispatch)) {
+      check(dispatch, is.func, 'dispatch must be a function')
     }
   }
 
@@ -76,8 +78,7 @@ export function runSaga(options, saga, ...args) {
   }
 
   const env = {
-    stdChannel: channel,
-    dispatch: wrapSagaDispatch(dispatch),
+    channel: channel._connect(dispatch || channel.put),
     getState,
     sagaMonitor,
     logError,

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -1,6 +1,6 @@
 import _extends from '@babel/runtime/helpers/extends'
 import * as is from '@redux-saga/is'
-import { SAGA_ACTION, TASK, TASK_CANCEL, TERMINATE } from '@redux-saga/symbols'
+import { TASK, TASK_CANCEL, TERMINATE } from '@redux-saga/symbols'
 
 export const konst = v => () => v
 export const kTrue = konst(true)
@@ -130,23 +130,6 @@ export const internalErr = err =>
 
 export const createSetContextWarning = (ctx, props) =>
   `${ctx ? ctx + '.' : ''}setContext(props): argument ${props} is not a plain object`
-
-const FROZEN_ACTION_ERROR = `You can't put (a.k.a. dispatch from saga) frozen actions.
-We have to define a special non-enumerable property on those actions for scheduling purposes.
-Otherwise you wouldn't be able to communicate properly between sagas & other subscribers (action ordering would become far less predictable).
-If you are using redux and you care about this behaviour (frozen actions),
-then you might want to switch to freezing actions in a middleware rather than in action creator.
-Example implementation:
-
-const freezeActions = store => next => action => next(Object.freeze(action))
-`
-
-export const wrapSagaDispatch = dispatch => action => {
-  if (process.env.NODE_ENV !== 'production') {
-    check(action, ac => !Object.isFrozen(ac), FROZEN_ACTION_ERROR)
-  }
-  return dispatch(Object.defineProperty(action, SAGA_ACTION, { value: true }))
-}
 
 export const cloneableGenerator = generatorFunc => (...args) => {
   const history = []


### PR DESCRIPTION
| Q                       | A              |
| ----------------------- | -------------- |
| Fixed Issues?           |                |
| Patch: Bug Fix?         |                |
| Major: Breaking Change? | See below      |
| Minor: New Feature?     |    👍         |
| Tests Added + Pass?     | 👍  |
| Documentation           | Need to update |
| Any Dependency Changes? |                |

In this PR, stdChannels become enhanceable version of multicast channels. A enhanceable channel has three extra methods (one public, and two private/internal):

- `enhanceable.enhancePut(fn)`: fn is a function that accepts the original put, and return a new put. The new put will replace the original put of the channel. Method `enhancePut` is used to handle monkey-patching of `channel.put`.
- `enhanceable._clone()`: `enhancePut(fn)` mutates channel object in-place. Calling `_clone()` will return a cloned enhanceable, and enhancement to the cloned will not affect the original.
- `enhanceable._connect(dispatch)`: connect channel to external I/O. This method returns a connected-channel. `dispatch` is used as **the put handler** for the connected-channel.

`env.dispatch` is removed in this PR, and all input/output of running saga is done via `env.channel`. This makes sagas a little purer (requires less knowledge about the outer world).

Advantages that the PR brings:

* a unified way of changing channle.put
* options are more consistent between `sagaMiddlewareFactory` and `runSaga`

## Public changes:

- stdChannel instances have a new public method `enhancePut`. Users could use this method to enhance `channel.put`.
- **BREAKING CHANGE**  `options.emitter` of `sagaMiddlewareFactory` is removed. Instead, `options.channel` is added, users could create a stdChannel and enhance it with the emitter to achieve the same goal of the old `options.emitter`. This make `sagaMiddlewareFactory()` and `runSaga()` more consistent in options: `runSaga#options` only has two more fields (i.e. dispatch and getState) than `sagaMiddlewareFactory#options`.