### PR TITLE
Add default type to PutEffect

### DIFF
--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -1,4 +1,4 @@
-import {Action} from "redux";
+import {Action, AnyAction} from "redux";
 import {
   END, TakeableChannel, PuttableChannel, FlushableChannel,
   Task, Buffer, Predicate,
@@ -74,7 +74,7 @@ export interface ChannelPutEffectDescriptor<T> {
   resolve?: boolean;
 }
 
-export interface PutEffect<A extends Action> {
+export interface PutEffect<A extends Action = AnyAction> {
   type: 'PUT';
   payload: PutEffectDescriptor<A>;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji ) --> |
| ------------------------ | ---  |
| Fixed Issues?            | - |
| Patch: Bug Fix?          |  No  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  Yes  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |  No  |

<!-- Describe your changes below in as much detail as possible -->

Just a small change to the TypeScript definition of the `PutEffect`. With the default type to it's generic argument you don't have to provide `PutEffect<any>` all the time (when you want to ignore the action completely) and just can use `PutEffect`.