### PR TITLE
Make `detach` immutable

### DIFF
--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -1,7 +1,7 @@
 import delayP from '@redux-saga/delay-p'
 import * as is from '@redux-saga/is'
 import { IO, SELF_CANCELLATION } from '@redux-saga/symbols'
-import { identity, check, createSetContextWarning } from './utils'
+import { check, createSetContextWarning, identity } from './utils'
 import * as effectTypes from './effectTypes'
 
 const TEST_HINT =
@@ -9,14 +9,13 @@ const TEST_HINT =
 
 const makeEffect = (type, payload) => ({ [IO]: true, type, payload })
 
-const isForkEffect = eff => eff && eff[IO] && eff.type === 'FORK'
+const isForkEffect = eff => eff && eff[IO] && eff.type === effectTypes.FORK
 
 export const detach = eff => {
   if (process.env.NODE_ENV === 'development') {
     check(eff, isForkEffect, 'detach(eff): argument must be a fork effect')
   }
-  eff.payload.detached = true
-  return eff
+  return makeEffect(effectTypes.FORK, { ...eff.payload, detached: true })
 }
 
 export function take(patternOrChannel = '*', multicastPattern) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |  Yes, but it is unlikely to break things |
| Minor: New Feature?      |    |
| Tests Added + Pass?      |   |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
Make `detach` immutable that returns a new effect rather than modifying the argument. Since we are treating effects as immutable objects, and we encourage users to treat effects as opaque objects, so it is better not to modify effects.
