### PR TITLE
Strict check for argument `pattern` in io.actionChannel

### DIFF
--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -163,7 +163,7 @@ export function select(selector = identity, ...args) {
 **/
 export function actionChannel(pattern, buffer) {
   if (process.env.NODE_ENV === 'development') {
-    check(pattern, is.notUndef, 'actionChannel(pattern,...): argument pattern is undefined')
+    check(pattern, is.pattern, 'actionChannel(pattern,...): argument pattern is not valid')
 
     if (arguments.length > 1) {
       check(buffer, is.notUndef, 'actionChannel(pattern, buffer): argument buffer is undefined')


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #1532 |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      |  |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
Use `is.pattern` to check argument `pattern` instead of `is.notUndef`. Error with an *invalid pattern* message will be thrown when constructing the action-channel, so it is much easier to debug errors in #1532.
