### PR TITLE
Fixed memory leak for closed actionChannels

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -651,6 +651,13 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
       chan.put(action)
     }
 
+    const { close } = chan
+
+    chan.close = () => {
+      taker.cancel()
+      close()
+    }
+
     env.stdChannel.take(taker, match)
     cb(chan)
   }


### PR DESCRIPTION
I don't think this can be tested easily - from the tests we can't check if there is a leak or not as it is observable only internally.