### PR TITLE
Add `immediately` in scheduler.js

### DIFF
--- a/packages/core/__tests__/scheduler.js
+++ b/packages/core/__tests__/scheduler.js
@@ -1,4 +1,5 @@
-import { asap, flush, suspend } from '../src/internal/scheduler'
+import { asap, immediately } from '../src/internal/scheduler'
+
 test('scheduler executes all recursively triggered tasks in order', () => {
   const actual = []
   asap(() => {
@@ -12,18 +13,19 @@ test('scheduler executes all recursively triggered tasks in order', () => {
   })
   expect(actual).toEqual(['1', '2', '3'])
 })
+
 test('scheduler when suspended queues up and executes all tasks on flush', () => {
   const actual = []
-  suspend()
-  asap(() => {
-    actual.push('1')
+  immediately(() => {
     asap(() => {
-      actual.push('2')
-    })
-    asap(() => {
-      actual.push('3')
+      actual.push('1')
+      asap(() => {
+        actual.push('2')
+      })
+      asap(() => {
+        actual.push('3')
+      })
     })
   })
-  flush()
   expect(actual).toEqual(['1', '2', '3'])
 })

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -20,7 +20,7 @@ import {
 
 import { getLocation, addSagaStack, sagaStackToString } from './error-utils'
 
-import { asap, suspend, flush } from './scheduler'
+import { asap, immediately } from './scheduler'
 import { channel, isEnd } from './channel'
 import matcher from './matcher'
 
@@ -508,8 +508,8 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
   function runForkEffect({ context, fn, args, detached }, effectId, cb) {
     const taskIterator = createTaskIterator({ context, fn, args })
     const meta = getIteratorMetaInfo(taskIterator, fn)
-    try {
-      suspend()
+
+    immediately(() => {
       const task = proc(env, taskIterator, taskContext, effectId, meta, detached ? null : noop)
 
       if (detached) {
@@ -524,9 +524,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
           cb(task)
         }
       }
-    } finally {
-      flush()
-    }
+    })
     // Fork effects are non cancellables
   }
 

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -3,7 +3,7 @@ import { compose } from 'redux'
 import { check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log } from './utils'
 import proc, { getMetaInfo } from './proc'
 import { stdChannel } from './channel'
-import { suspend, flush } from './scheduler'
+import { immediately } from './scheduler'
 
 const RUN_SAGA_SIGNATURE = 'runSaga(options, saga, ...args)'
 const NON_GENERATOR_ERR = `${RUN_SAGA_SIGNATURE}: saga argument must be a Generator function!`
@@ -86,8 +86,7 @@ export function runSaga(options, saga, ...args) {
     finalizeRunEffect,
   }
 
-  try {
-    suspend()
+  return immediately(() => {
     const task = proc(env, iterator, context, effectId, getMetaInfo(saga), null)
 
     if (sagaMonitor) {
@@ -95,7 +94,5 @@ export function runSaga(options, saga, ...args) {
     }
 
     return task
-  } finally {
-    flush()
-  }
+  })
 }

--- a/packages/core/src/internal/scheduler.js
+++ b/packages/core/src/internal/scheduler.js
@@ -35,10 +35,22 @@ export function asap(task) {
 }
 
 /**
+ * Puts the scheduler in a `suspended` state and executes a task immediately.
+ */
+export function immediately(task) {
+  try {
+    suspend()
+    return task()
+  } finally {
+    flush()
+  }
+}
+
+/**
   Puts the scheduler in a `suspended` state. Scheduled tasks will be queued until the
   scheduler is released.
 **/
-export function suspend() {
+function suspend() {
   semaphore++
 }
 
@@ -52,7 +64,7 @@ function release() {
 /**
   Releases the current lock. Executes all queued tasks if the scheduler is in the released state.
 **/
-export function flush() {
+function flush() {
   release()
 
   let task


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |    |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | 👍 |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
We was using a pair of `suspend` and `flush` to schedule fork-effect and root-saga execution. In this PR, I add `immediately` in schedulers.js to replace the `suspend/flush` pair.

`immediately` is very much like `asap`, but it puts the scheduler in suspended state and then executes the task immediately. This PR is just an enhancement of coding style, the actual code execution order should be same as before.