### PR TITLE
Add node the latest stable version for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10.2.1"
+  - "11.0.0"
 
 script:
   - npm run check


### PR DESCRIPTION
## Summary

This PR adds `node` since Node.js `11` has been released.

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.0.0

## Details
#### [Specifying Node.js versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions)
> Specifying Node.js versions #
> The easiest way to specify Node.js versions is to use one or more of the latest releases in your .travis.yml:
> 
> node latest stable Node.js release
> iojs latest stable io.js release
> lts/* latest LTS Node.js release
> 