### PR TITLE
Refactor signature of sagaMiddleware options.

### DIFF
--- a/packages/core/__tests__/middleware.js
+++ b/packages/core/__tests__/middleware.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware } from 'redux'
 import sagaMiddleware, { stdChannel } from '../src'
 import * as is from '@redux-saga/is'
-import { takeEvery } from '../src/effects'
+import { put, takeEvery } from '../src/effects'
 
 test('middleware output', () => {
   const middleware = sagaMiddleware() // middleware factory must return a function to handle {getState, dispatch}
@@ -94,7 +94,10 @@ test('enhance channel.put with an emitter', () => {
   }
 
   function* saga() {
-    yield takeEvery('*', ac => actual.push(ac.type))
+    yield takeEvery(ac => ac.type.length === 1, function*(ac) {
+      actual.push(ac.type)
+      yield put({ type: `put_${ac.type}` })
+    })
   }
 
   const middleware = sagaMiddleware({ channel })
@@ -108,7 +111,7 @@ test('enhance channel.put with an emitter', () => {
   store.dispatch({ type: 'e' })
 
   // saga must be able to take actions emitted by middleware's custom emitter
-  const expected = ['a', 'b', 'c', 'd', 'e']
+  const expected = ['a', 'put_a', 'b', 'put_b', 'c', 'put_c', 'd', 'put_d', 'e', 'put_e']
   expect(actual).toEqual(expected)
 })
 

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -52,7 +52,7 @@ export function put(channel, action) {
   }
   if (is.undef(action)) {
     action = channel
-    channel = null
+    channel = undefined
   }
   return makeEffect(effectTypes.PUT, { channel, action })
 }

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -52,6 +52,7 @@ export function put(channel, action) {
   }
   if (is.undef(action)) {
     action = channel
+    // `undefined` instead of `null` to make default parameter work
     channel = undefined
   }
   return makeEffect(effectTypes.PUT, { channel, action })

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -3,17 +3,16 @@ import { check, assignWithSymbols, createSetContextWarning } from './utils'
 import { stdChannel } from './channel'
 import { runSaga } from './runSaga'
 
-export default function sagaMiddlewareFactory(options = {}) {
-  const { context = {}, channel = stdChannel(), sagaMonitor, logger, onError, effectMiddlewares } = options
+export default function sagaMiddlewareFactory({ context = {}, channel = stdChannel(), sagaMonitor, ...options } = {}) {
   let boundRunSaga
 
   if (process.env.NODE_ENV !== 'production') {
-    if (is.notUndef(logger)) {
-      check(logger, is.func, 'options.logger passed to the Saga middleware is not a function!')
+    if (is.notUndef(options.logger)) {
+      check(options.logger, is.func, 'options.logger passed to the Saga middleware is not a function!')
     }
 
-    if (is.notUndef(onError)) {
-      check(onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
+    if (is.notUndef(options.onError)) {
+      check(options.onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
     }
 
     check(channel, is.channel, 'options.channel passed to the Saga middleware is not a channel')
@@ -21,14 +20,12 @@ export default function sagaMiddlewareFactory(options = {}) {
 
   function sagaMiddleware({ getState, dispatch }) {
     boundRunSaga = runSaga.bind(null, {
+      ...options,
       context,
       channel,
       dispatch,
       getState,
       sagaMonitor,
-      logger,
-      onError,
-      effectMiddlewares,
     })
 
     return next => action => {

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -1,11 +1,10 @@
 import * as is from '@redux-saga/is'
 import { check, assignWithSymbols, createSetContextWarning } from './utils'
 import { stdChannel } from './channel'
-import { identity } from './utils'
 import { runSaga } from './runSaga'
 
-export default function sagaMiddlewareFactory({ context = {}, ...options } = {}) {
-  const { sagaMonitor, logger, onError, effectMiddlewares } = options
+export default function sagaMiddlewareFactory(options = {}) {
+  const { context = {}, channel = stdChannel(), sagaMonitor, logger, onError, effectMiddlewares } = options
   let boundRunSaga
 
   if (process.env.NODE_ENV !== 'production') {
@@ -17,15 +16,10 @@ export default function sagaMiddlewareFactory({ context = {}, ...options } = {})
       check(onError, is.func, 'options.onError passed to the Saga middleware is not a function!')
     }
 
-    if (is.notUndef(options.emitter)) {
-      check(options.emitter, is.func, 'options.emitter passed to the Saga middleware is not a function!')
-    }
+    check(channel, is.channel, 'options.channel passed to the Saga middleware is not a channel')
   }
 
   function sagaMiddleware({ getState, dispatch }) {
-    const channel = stdChannel()
-    channel.put = (options.emitter || identity)(channel.put)
-
     boundRunSaga = runSaga.bind(null, {
       context,
       channel,

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -32,7 +32,8 @@ export default function sagaMiddlewareFactory(options = {}) {
     })
 
     return next => action => {
-      if (sagaMonitor && sagaMonitor.actionDispatched) {
+      // if `sagaMonitor` got passed in `runSaga` defaults `actionDispatched` to `noop`
+      if (sagaMonitor) {
         sagaMonitor.actionDispatched(action)
       }
       const result = next(action) // hit reducers

--- a/packages/core/src/internal/middleware.js
+++ b/packages/core/src/internal/middleware.js
@@ -29,8 +29,7 @@ export default function sagaMiddlewareFactory({ context = {}, channel = stdChann
     })
 
     return next => action => {
-      // if `sagaMonitor` got passed in `runSaga` defaults `actionDispatched` to `noop`
-      if (sagaMonitor) {
+      if (sagaMonitor && sagaMonitor.actionDispatched) {
         sagaMonitor.actionDispatched(action)
       }
       const result = next(action) // hit reducers

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -423,7 +423,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     proc(env, iterator, taskContext, effectId, meta, /* isRoot */ false, cb)
   }
 
-  function runTakeEffect({ channel = env.stdChannel, pattern, maybe }, cb) {
+  function runTakeEffect({ channel = env.channel, pattern, maybe }, cb) {
     const takeCb = input => {
       if (input instanceof Error) {
         cb(input, true)
@@ -444,7 +444,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     cb.cancel = takeCb.cancel
   }
 
-  function runPutEffect({ channel, action, resolve }, cb) {
+  function runPutEffect({ channel = env.channel, action, resolve }, cb) {
     /**
       Schedule the put in case another saga is holding a lock.
       The put will be executed atomically. ie nested puts will execute after
@@ -453,7 +453,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     asap(() => {
       let result
       try {
-        result = (channel ? channel.put : env.dispatch)(action)
+        result = channel.put(action)
       } catch (error) {
         cb(error, true)
         return
@@ -643,7 +643,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
     const taker = action => {
       if (!isEnd(action)) {
-        env.stdChannel.take(taker, match)
+        env.channel.take(taker, match)
       }
       chan.put(action)
     }
@@ -655,7 +655,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
       close()
     }
 
-    env.stdChannel.take(taker, match)
+    env.channel.take(taker, match)
     cb(chan)
   }
 

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -444,7 +444,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     cb.cancel = takeCb.cancel
   }
 
-  function runPutEffect({ channel = env.channel, action, resolve }, cb) {
+  function runPutEffect({ channel, action, resolve }, cb) {
     /**
       Schedule the put in case another saga is holding a lock.
       The put will be executed atomically. ie nested puts will execute after
@@ -453,7 +453,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     asap(() => {
       let result
       try {
-        result = channel.put(action)
+        result = (channel ? channel.put : env.dispatch)(action)
       } catch (error) {
         cb(error, true)
         return

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -8,7 +8,11 @@ import { immediately } from './scheduler'
 const RUN_SAGA_SIGNATURE = 'runSaga(options, saga, ...args)'
 const NON_GENERATOR_ERR = `${RUN_SAGA_SIGNATURE}: saga argument must be a Generator function!`
 
-export function runSaga(options, saga, ...args) {
+export function runSaga(
+  { channel = stdChannel(), dispatch, getState, context = {}, sagaMonitor, logger, effectMiddlewares, onError },
+  saga,
+  ...args
+) {
   if (process.env.NODE_ENV !== 'production') {
     check(saga, is.func, NON_GENERATOR_ERR)
   }
@@ -18,17 +22,6 @@ export function runSaga(options, saga, ...args) {
   if (process.env.NODE_ENV !== 'production') {
     check(iterator, is.iterator, NON_GENERATOR_ERR)
   }
-
-  const {
-    channel = stdChannel(),
-    dispatch,
-    getState,
-    context = {},
-    sagaMonitor,
-    logger,
-    effectMiddlewares,
-    onError,
-  } = options
 
   const effectId = nextSagaId()
 

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -79,7 +79,8 @@ export function runSaga(
   }
 
   const env = {
-    channel: { ...channel, put: wrapSagaDispatch(dispatch || channel.put) },
+    channel,
+    dispatch: wrapSagaDispatch(dispatch),
     getState,
     sagaMonitor,
     logError,

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -44,13 +44,21 @@ export function runSaga(options, saga, ...args) {
     sagaMonitor.rootSagaStarted({ effectId, saga, args })
   }
 
-  if (process.env.NODE_ENV !== 'production' && is.notUndef(effectMiddlewares)) {
-    const MIDDLEWARE_TYPE_ERROR = 'effectMiddlewares must be an array of functions'
-    check(effectMiddlewares, is.array, MIDDLEWARE_TYPE_ERROR)
-    effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
-  }
-
   if (process.env.NODE_ENV !== 'production') {
+    if (is.notUndef(dispatch)) {
+      check(dispatch, is.func, 'dispatch must be a function')
+    }
+
+    if (is.notUndef(getState)) {
+      check(getState, is.func, 'getState must be a function')
+    }
+
+    if (is.notUndef(effectMiddlewares)) {
+      const MIDDLEWARE_TYPE_ERROR = 'effectMiddlewares must be an array of functions'
+      check(effectMiddlewares, is.array, MIDDLEWARE_TYPE_ERROR)
+      effectMiddlewares.forEach(effectMiddleware => check(effectMiddleware, is.func, MIDDLEWARE_TYPE_ERROR))
+    }
+
     if (is.notUndef(onError)) {
       check(onError, is.func, 'onError must be a function')
     }
@@ -77,8 +85,7 @@ export function runSaga(options, saga, ...args) {
   }
 
   const env = {
-    stdChannel: channel,
-    dispatch: wrapSagaDispatch(dispatch),
+    channel: { ...channel, put: wrapSagaDispatch(dispatch || channel.put) },
     getState,
     sagaMonitor,
     logError,


### PR DESCRIPTION
| Q                       | A              |
| ----------------------- | -------------- |
| Fixed Issues?           |                |
| Patch: Bug Fix?         |                |
| Major: Breaking Change? | See below      |
| Minor: New Feature?     |             |
| Tests Added + Pass?     | 👍  |
| Documentation           | Need to update |
| Any Dependency Changes? |                |

This PR is a subset of #1528. `options.emitter` is removed from `sagaMiddlewareFactory`, instead `options.channel` is added, so users can enhance a channel and pass the channel to the middleware to get the same effect as the `options.emitter`. Note that it is a breaking change.
