### PR TITLE
Move all effect runners to a separated file

### DIFF
--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -124,10 +124,18 @@ export function runCPSEffect(env, { context, fn, args }, cb) {
 
   // catch synchronous failures; see #152
   try {
-    const cpsCb = (err, res) => (is.undef(err) ? cb(res) : cb(err, true))
+    const cpsCb = (err, res) => {
+      if (is.undef(err)) {
+        cb(res)
+      } else {
+        cb(err, true)
+      }
+    }
+
     fn.apply(context, args.concat(cpsCb))
+
     if (cpsCb.cancel) {
-      cb.cancel = () => cpsCb.cancel()
+      cb.cancel = cpsCb.cancel
     }
   } catch (error) {
     cb(error, true)

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -10,9 +10,9 @@ import matcher from './matcher'
 import { asap, immediately } from './scheduler'
 import { getMetaInfo } from './error-utils'
 import {
-  array,
   assignWithSymbols,
   createAllStyleChildCallbacks,
+  createEmptyArray,
   makeIterator,
   noop,
   remove,
@@ -222,12 +222,15 @@ function runAllEffect(env, effects, cb, { effectId, digestEffect }) {
   }
 
   const childCallbacks = createAllStyleChildCallbacks(effects, cb)
-  keys.forEach(key => digestEffect(effects[key], effectId, key, childCallbacks[key]))
+  keys.forEach(key => {
+    digestEffect(effects[key], effectId, key, childCallbacks[key])
+  })
 }
 
 function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
   let completed
   const keys = Object.keys(effects)
+  const response = is.array(effects) ? createEmptyArray(keys.length) : {}
   const childCbs = {}
 
   keys.forEach(key => {
@@ -242,8 +245,8 @@ function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
       } else {
         cb.cancel()
         completed = true
-        const response = { [key]: res }
-        cb(is.array(effects) ? array.from({ ...response, length: keys.length }) : response)
+        response[key] = res
+        cb(response)
       }
     }
     chCbAtKey.cancel = noop

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -1,0 +1,323 @@
+import { SELF_CANCELLATION, TERMINATE } from '@redux-saga/symbols'
+import * as is from '@redux-saga/is'
+import * as effectTypes from './effectTypes'
+import { channel, isEnd } from './channel'
+import proc from './proc'
+import matcher from './matcher'
+import { asap, immediately } from './scheduler'
+import { getMetaInfo } from './error-utils'
+import {
+  array,
+  assignWithSymbols,
+  createAllStyleChildCallbacks,
+  makeIterator,
+  noop,
+  remove,
+  shouldComplete,
+} from './utils'
+
+function getIteratorMetaInfo(iterator, fn) {
+  if (iterator.isSagaIterator) {
+    return { name: iterator.meta.name }
+  }
+  return getMetaInfo(fn)
+}
+
+function createTaskIterator({ context, fn, args }) {
+  // catch synchronous failures; see #152 and #441
+  try {
+    const result = fn.apply(context, args)
+
+    // i.e. a generator function returns an iterator
+    if (is.iterator(result)) {
+      return result
+    }
+
+    const next = (value = result) => ({
+      value,
+      done: !is.promise(value),
+    })
+
+    return makeIterator(next)
+  } catch (err) {
+    // do not bubble up synchronous failures for detached forks
+    // instead create a failed task. See #152 and #441
+    return makeIterator(() => {
+      throw err
+    })
+  }
+}
+
+export function runPutEffect(env, { channel, action, resolve }, cb, { resolvePromise }) {
+  /**
+   Schedule the put in case another saga is holding a lock.
+   The put will be executed atomically. ie nested puts will execute after
+   this put has terminated.
+   **/
+  asap(() => {
+    let result
+    try {
+      result = (channel ? channel.put : env.dispatch)(action)
+    } catch (error) {
+      cb(error, true)
+      return
+    }
+
+    if (resolve && is.promise(result)) {
+      resolvePromise(result, cb)
+    } else {
+      cb(result)
+    }
+  })
+  // Put effects are non cancellables
+}
+
+export function runTakeEffect(env, { channel = env.channel, pattern, maybe }, cb) {
+  const takeCb = input => {
+    if (input instanceof Error) {
+      cb(input, true)
+      return
+    }
+    if (isEnd(input) && !maybe) {
+      cb(TERMINATE)
+      return
+    }
+    cb(input)
+  }
+  try {
+    channel.take(takeCb, is.notUndef(pattern) ? matcher(pattern) : null)
+  } catch (err) {
+    cb(err, true)
+    return
+  }
+  cb.cancel = takeCb.cancel
+}
+
+export function runCallEffect(env, { context, fn, args }, cb, { effectId, resolvePromise, resolveIterator }) {
+  // catch synchronous failures; see #152
+  try {
+    const result = fn.apply(context, args)
+
+    if (is.promise(result)) {
+      resolvePromise(result, cb)
+      return
+    }
+
+    if (is.iterator(result)) {
+      resolveIterator(result, effectId, getMetaInfo(fn), cb)
+      return
+    }
+
+    cb(result)
+  } catch (error) {
+    cb(error, true)
+  }
+}
+
+export function runCPSEffect(env, { context, fn, args }, cb) {
+  // CPS (ie node style functions) can define their own cancellation logic
+  // by setting cancel field on the cb
+
+  // catch synchronous failures; see #152
+  try {
+    const cpsCb = (err, res) => (is.undef(err) ? cb(res) : cb(err, true))
+    fn.apply(context, args.concat(cpsCb))
+    if (cpsCb.cancel) {
+      cb.cancel = () => cpsCb.cancel()
+    }
+  } catch (error) {
+    cb(error, true)
+  }
+}
+
+export function runForkEffect(env, { context, fn, args, detached }, cb, { effectId, taskContext, taskQueue }) {
+  const taskIterator = createTaskIterator({ context, fn, args })
+  const meta = getIteratorMetaInfo(taskIterator, fn)
+
+  immediately(() => {
+    const task = proc(env, taskIterator, taskContext, effectId, meta, detached, noop)
+
+    if (detached) {
+      cb(task)
+    } else {
+      if (task._isRunning) {
+        taskQueue.addTask(task)
+        cb(task)
+      } else if (task._error) {
+        taskQueue.abort(task._error)
+      } else {
+        cb(task)
+      }
+    }
+  })
+  // Fork effects are non cancellables
+}
+
+export function runJoinEffect(env, taskOrTasks, cb, { task }) {
+  if (is.array(taskOrTasks)) {
+    if (taskOrTasks.length === 0) {
+      cb([])
+      return
+    }
+
+    const childCallbacks = createAllStyleChildCallbacks(taskOrTasks, cb)
+    taskOrTasks.forEach((t, i) => {
+      joinSingleTask(t, childCallbacks[i])
+    })
+  } else {
+    joinSingleTask(taskOrTasks, cb)
+  }
+
+  function joinSingleTask(taskToJoin, cb) {
+    if (taskToJoin.isRunning()) {
+      const joiner = { task, cb }
+      cb.cancel = () => remove(taskToJoin.joiners, joiner)
+      taskToJoin.joiners.push(joiner)
+    } else {
+      if (taskToJoin.isAborted()) {
+        cb(taskToJoin.error(), true)
+      } else {
+        cb(taskToJoin.result())
+      }
+    }
+  }
+}
+
+export function runCancelEffect(env, taskOrTasks, cb, { task }) {
+  if (taskOrTasks === SELF_CANCELLATION) {
+    cancelSingleTask(task)
+  } else if (is.array(taskOrTasks)) {
+    taskOrTasks.forEach(cancelSingleTask)
+  } else {
+    cancelSingleTask(taskOrTasks)
+  }
+  cb()
+
+  // cancel effects are non cancellables
+
+  function cancelSingleTask(taskToCancel) {
+    if (taskToCancel.isRunning()) {
+      taskToCancel.cancel()
+    }
+  }
+}
+
+export function runAllEffect(env, effects, cb, { effectId, digestEffect }) {
+  const keys = Object.keys(effects)
+  if (keys.length === 0) {
+    cb(is.array(effects) ? [] : {})
+    return
+  }
+
+  const childCallbacks = createAllStyleChildCallbacks(effects, cb)
+  keys.forEach(key => digestEffect(effects[key], effectId, key, childCallbacks[key]))
+}
+
+export function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
+  let completed
+  const keys = Object.keys(effects)
+  const childCbs = {}
+
+  keys.forEach(key => {
+    const chCbAtKey = (res, isErr) => {
+      if (completed) {
+        return
+      }
+      if (isErr || shouldComplete(res)) {
+        // Race Auto cancellation
+        cb.cancel()
+        cb(res, isErr)
+      } else {
+        cb.cancel()
+        completed = true
+        const response = { [key]: res }
+        cb(is.array(effects) ? array.from({ ...response, length: keys.length }) : response)
+      }
+    }
+    chCbAtKey.cancel = noop
+    childCbs[key] = chCbAtKey
+  })
+
+  cb.cancel = () => {
+    // prevents unnecessary cancellation
+    if (!completed) {
+      completed = true
+      keys.forEach(key => childCbs[key].cancel())
+    }
+  }
+  keys.forEach(key => {
+    if (completed) {
+      return
+    }
+    digestEffect(effects[key], effectId, key, childCbs[key])
+  })
+}
+
+export function runSelectEffect(env, { selector, args }, cb) {
+  try {
+    const state = selector(env.getState(), ...args)
+    cb(state)
+  } catch (error) {
+    cb(error, true)
+  }
+}
+
+export function runChannelEffect(env, { pattern, buffer }, cb) {
+  // TODO: rethink how END is handled
+  const chan = channel(buffer)
+  const match = matcher(pattern)
+
+  const taker = action => {
+    if (!isEnd(action)) {
+      env.channel.take(taker, match)
+    }
+    chan.put(action)
+  }
+
+  const { close } = chan
+
+  chan.close = () => {
+    taker.cancel()
+    close()
+  }
+
+  env.channel.take(taker, match)
+  cb(chan)
+}
+
+export function runCancelledEffect(env, data, cb, { mainTask }) {
+  cb(mainTask._isCancelled)
+}
+
+export function runFlushEffect(env, channel, cb) {
+  channel.flush(cb)
+}
+
+export function runGetContextEffect(env, prop, cb, { taskContext }) {
+  cb(taskContext[prop])
+}
+
+export function runSetContextEffect(env, props, cb, { taskContext }) {
+  assignWithSymbols(taskContext, props)
+  cb()
+}
+
+const effectRunnerMap = {
+  [effectTypes.TAKE]: runTakeEffect,
+  [effectTypes.PUT]: runPutEffect,
+  [effectTypes.ALL]: runAllEffect,
+  [effectTypes.RACE]: runRaceEffect,
+  [effectTypes.CALL]: runCallEffect,
+  [effectTypes.CPS]: runCPSEffect,
+  [effectTypes.FORK]: runForkEffect,
+  [effectTypes.JOIN]: runJoinEffect,
+  [effectTypes.CANCEL]: runCancelEffect,
+  [effectTypes.SELECT]: runSelectEffect,
+  [effectTypes.ACTION_CHANNEL]: runChannelEffect,
+  [effectTypes.CANCELLED]: runCancelledEffect,
+  [effectTypes.FLUSH]: runFlushEffect,
+  [effectTypes.GET_CONTEXT]: runGetContextEffect,
+  [effectTypes.SET_CONTEXT]: runSetContextEffect,
+}
+
+export default effectRunnerMap

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -51,7 +51,7 @@ function createTaskIterator({ context, fn, args }) {
   }
 }
 
-export function runPutEffect(env, { channel, action, resolve }, cb) {
+function runPutEffect(env, { channel, action, resolve }, cb) {
   /**
    Schedule the put in case another saga is holding a lock.
    The put will be executed atomically. ie nested puts will execute after
@@ -75,7 +75,7 @@ export function runPutEffect(env, { channel, action, resolve }, cb) {
   // Put effects are non cancellables
 }
 
-export function runTakeEffect(env, { channel = env.channel, pattern, maybe }, cb) {
+function runTakeEffect(env, { channel = env.channel, pattern, maybe }, cb) {
   const takeCb = input => {
     if (input instanceof Error) {
       cb(input, true)
@@ -96,7 +96,7 @@ export function runTakeEffect(env, { channel = env.channel, pattern, maybe }, cb
   cb.cancel = takeCb.cancel
 }
 
-export function runCallEffect(env, { context, fn, args }, cb, { effectId, taskContext }) {
+function runCallEffect(env, { context, fn, args }, cb, { effectId, taskContext }) {
   // catch synchronous failures; see #152
   try {
     const result = fn.apply(context, args)
@@ -118,7 +118,7 @@ export function runCallEffect(env, { context, fn, args }, cb, { effectId, taskCo
   }
 }
 
-export function runCPSEffect(env, { context, fn, args }, cb) {
+function runCPSEffect(env, { context, fn, args }, cb) {
   // CPS (ie node style functions) can define their own cancellation logic
   // by setting cancel field on the cb
 
@@ -142,7 +142,7 @@ export function runCPSEffect(env, { context, fn, args }, cb) {
   }
 }
 
-export function runForkEffect(env, { context, fn, args, detached }, cb, { effectId, taskContext, taskQueue }) {
+function runForkEffect(env, { context, fn, args, detached }, cb, { effectId, taskContext, taskQueue }) {
   const taskIterator = createTaskIterator({ context, fn, args })
   const meta = getIteratorMetaInfo(taskIterator, fn)
 
@@ -165,7 +165,7 @@ export function runForkEffect(env, { context, fn, args, detached }, cb, { effect
   // Fork effects are non cancellables
 }
 
-export function runJoinEffect(env, taskOrTasks, cb, { task }) {
+function runJoinEffect(env, taskOrTasks, cb, { task }) {
   if (is.array(taskOrTasks)) {
     if (taskOrTasks.length === 0) {
       cb([])
@@ -195,7 +195,7 @@ export function runJoinEffect(env, taskOrTasks, cb, { task }) {
   }
 }
 
-export function runCancelEffect(env, taskOrTasks, cb, { task }) {
+function runCancelEffect(env, taskOrTasks, cb, { task }) {
   if (taskOrTasks === SELF_CANCELLATION) {
     cancelSingleTask(task)
   } else if (is.array(taskOrTasks)) {
@@ -214,7 +214,7 @@ export function runCancelEffect(env, taskOrTasks, cb, { task }) {
   }
 }
 
-export function runAllEffect(env, effects, cb, { effectId, digestEffect }) {
+function runAllEffect(env, effects, cb, { effectId, digestEffect }) {
   const keys = Object.keys(effects)
   if (keys.length === 0) {
     cb(is.array(effects) ? [] : {})
@@ -225,7 +225,7 @@ export function runAllEffect(env, effects, cb, { effectId, digestEffect }) {
   keys.forEach(key => digestEffect(effects[key], effectId, key, childCallbacks[key]))
 }
 
-export function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
+function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
   let completed
   const keys = Object.keys(effects)
   const childCbs = {}
@@ -265,7 +265,7 @@ export function runRaceEffect(env, effects, cb, { effectId, digestEffect }) {
   })
 }
 
-export function runSelectEffect(env, { selector, args }, cb) {
+function runSelectEffect(env, { selector, args }, cb) {
   try {
     const state = selector(env.getState(), ...args)
     cb(state)
@@ -274,7 +274,7 @@ export function runSelectEffect(env, { selector, args }, cb) {
   }
 }
 
-export function runChannelEffect(env, { pattern, buffer }, cb) {
+function runChannelEffect(env, { pattern, buffer }, cb) {
   // TODO: rethink how END is handled
   const chan = channel(buffer)
   const match = matcher(pattern)
@@ -297,19 +297,19 @@ export function runChannelEffect(env, { pattern, buffer }, cb) {
   cb(chan)
 }
 
-export function runCancelledEffect(env, data, cb, { mainTask }) {
+function runCancelledEffect(env, data, cb, { mainTask }) {
   cb(mainTask._isCancelled)
 }
 
-export function runFlushEffect(env, channel, cb) {
+function runFlushEffect(env, channel, cb) {
   channel.flush(cb)
 }
 
-export function runGetContextEffect(env, prop, cb, { taskContext }) {
+function runGetContextEffect(env, prop, cb, { taskContext }) {
   cb(taskContext[prop])
 }
 
-export function runSetContextEffect(env, props, cb, { taskContext }) {
+function runSetContextEffect(env, props, cb, { taskContext }) {
   assignWithSymbols(taskContext, props)
   cb()
 }

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -3,6 +3,7 @@ import * as is from '@redux-saga/is'
 import * as effectTypes from './effectTypes'
 import { channel, isEnd } from './channel'
 import proc from './proc'
+import resolvePromise from './resolvePromise'
 import matcher from './matcher'
 import { asap, immediately } from './scheduler'
 import { getMetaInfo } from './error-utils'
@@ -48,7 +49,7 @@ function createTaskIterator({ context, fn, args }) {
   }
 }
 
-export function runPutEffect(env, { channel, action, resolve }, cb, { resolvePromise }) {
+export function runPutEffect(env, { channel, action, resolve }, cb) {
   /**
    Schedule the put in case another saga is holding a lock.
    The put will be executed atomically. ie nested puts will execute after
@@ -93,7 +94,7 @@ export function runTakeEffect(env, { channel = env.channel, pattern, maybe }, cb
   cb.cancel = takeCb.cancel
 }
 
-export function runCallEffect(env, { context, fn, args }, cb, { effectId, resolvePromise, resolveIterator }) {
+export function runCallEffect(env, { context, fn, args }, cb, { effectId, resolveIterator }) {
   // catch synchronous failures; see #152
   try {
     const result = fn.apply(context, args)

--- a/packages/core/src/internal/error-utils.js
+++ b/packages/core/src/internal/error-utils.js
@@ -8,6 +8,13 @@ export function getLocation(instrumented) {
   return instrumented[SAGA_LOCATION]
 }
 
+export function getMetaInfo(fn) {
+  return {
+    name: fn.name || 'anonymous',
+    location: getLocation(fn),
+  }
+}
+
 function effectLocationAsString(effect) {
   const location = getLocation(effect)
   if (location) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -1,7 +1,8 @@
 import deferred from '@redux-saga/deferred'
 import * as is from '@redux-saga/is'
-import { CANCEL, IO, TASK, TASK_CANCEL } from '@redux-saga/symbols'
+import { IO, TASK, TASK_CANCEL } from '@redux-saga/symbols'
 import effectRunnerMap from './effectRunnerMap'
+import resolvePromise from './resolvePromise'
 import {
   noop,
   check,
@@ -287,7 +288,6 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
         mainTask,
         taskQueue,
         digestEffect,
-        resolvePromise,
         resolveIterator,
       }
       const effectRunner = effectRunnerMap[effect.type]
@@ -356,16 +356,6 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     }
 
     finalRunEffect(effect, effectId, currCb)
-  }
-
-  function resolvePromise(promise, cb) {
-    const cancelPromise = promise[CANCEL]
-    if (is.func(cancelPromise)) {
-      cb.cancel = cancelPromise
-    } else if (is.func(promise.abort)) {
-      cb.cancel = () => promise.abort()
-    }
-    promise.then(cb, error => cb(error, true))
   }
 
   function resolveIterator(iterator, effectId, meta, cb) {

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -279,7 +279,8 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     if (is.promise(effect)) {
       resolvePromise(effect, currCb)
     } else if (is.iterator(effect)) {
-      resolveIterator(effect, effectId, meta, currCb)
+      // resolve iterator
+      proc(env, effect, taskContext, effectId, meta, /* isRoot */ false, currCb)
     } else if (effect && effect[IO]) {
       const executingContext = {
         effectId,
@@ -288,7 +289,6 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
         mainTask,
         taskQueue,
         digestEffect,
-        resolveIterator,
       }
       const effectRunner = effectRunnerMap[effect.type]
       effectRunner(env, effect.payload, currCb, executingContext)
@@ -356,10 +356,6 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     }
 
     finalRunEffect(effect, effectId, currCb)
-  }
-
-  function resolveIterator(iterator, effectId, meta, cb) {
-    proc(env, iterator, taskContext, effectId, meta, /* isRoot */ false, cb)
   }
 
   function newTask(id, meta, isRoot, cont) {

--- a/packages/core/src/internal/resolvePromise.js
+++ b/packages/core/src/internal/resolvePromise.js
@@ -1,0 +1,14 @@
+import * as is from '@redux-saga/is'
+import { CANCEL } from '@redux-saga/symbols'
+
+export default function resolvePromise(promise, cb) {
+  const cancelPromise = promise[CANCEL]
+
+  if (is.func(cancelPromise)) {
+    cb.cancel = cancelPromise
+  }
+
+  promise.then(cb, error => {
+    cb(error, true)
+  })
+}

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,10 +1,11 @@
 import * as is from '@redux-saga/is'
 import { compose } from 'redux'
-import { check, log as _log, noop, uid as nextSagaId, wrapSagaDispatch, identity } from './utils'
+import { check, log as _log, noop, wrapSagaDispatch, identity } from './utils'
 import { getMetaInfo } from './error-utils'
 import proc from './proc'
 import { stdChannel } from './channel'
 import { immediately } from './scheduler'
+import nextSagaId from './uid'
 
 const RUN_SAGA_SIGNATURE = 'runSaga(options, saga, ...args)'
 const NON_GENERATOR_ERR = `${RUN_SAGA_SIGNATURE}: saga argument must be a Generator function!`

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -1,7 +1,8 @@
 import * as is from '@redux-saga/is'
 import { compose } from 'redux'
-import { check, uid as nextSagaId, wrapSagaDispatch, noop, log as _log, identity } from './utils'
-import proc, { getMetaInfo } from './proc'
+import { check, log as _log, noop, uid as nextSagaId, wrapSagaDispatch, identity } from './utils'
+import { getMetaInfo } from './error-utils'
+import proc from './proc'
 import { stdChannel } from './channel'
 import { immediately } from './scheduler'
 

--- a/packages/core/src/internal/uid.js
+++ b/packages/core/src/internal/uid.js
@@ -1,0 +1,3 @@
+export let current = 0
+
+export default () => ++current

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -67,12 +67,6 @@ export function createMockTask() {
   }
 }
 
-export function autoInc(seed = 0) {
-  return () => ++seed
-}
-
-export const uid = autoInc()
-
 const kThrow = err => {
   throw err
 }

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -39,18 +39,6 @@ export function remove(array, item) {
   }
 }
 
-export const array = {
-  from(obj) {
-    const arr = Array(obj.length)
-    for (let i in obj) {
-      if (hasOwn(obj, i)) {
-        arr[i] = obj[i]
-      }
-    }
-    return arr
-  },
-}
-
 export function once(fn) {
   let called = false
   return () => {
@@ -141,6 +129,9 @@ Example implementation:
 const freezeActions = store => next => action => next(Object.freeze(action))
 `
 
+// creates empty, but not-holey array
+export const createEmptyArray = n => Array.apply(null, new Array(n))
+
 export const wrapSagaDispatch = dispatch => action => {
   if (process.env.NODE_ENV !== 'production') {
     check(action, ac => !Object.isFrozen(ac), FROZEN_ACTION_ERROR)
@@ -180,17 +171,13 @@ export function createAllStyleChildCallbacks(shape, parentCallback) {
 
   let completedCount = 0
   let completed
-  const results = {}
+  const results = is.array(shape) ? createEmptyArray(totalCount) : {}
   const childCallbacks = {}
 
   function checkEnd() {
     if (completedCount === totalCount) {
       completed = true
-      if (is.array(shape)) {
-        parentCallback(array.from({ ...results, length: totalCount }))
-      } else {
-        parentCallback(results)
-      }
+      parentCallback(results)
     }
   }
 


### PR DESCRIPTION
This PR is a subset of #1524, hope this could be merged more easily.

In this PR, effect-runners have a unified function interface which can be seen in the new implementation of `runEffect` (the interface may need further discussion and refinement):

```javascript
function runEffect(effect, effectId, currCb) {
  if (is.promise(effect)) {
    resolvePromise(effect, currCb)
  } else if (is.iterator(effect)) {
    resolveIterator(effect, effectId, meta, currCb)
  } else if (effect && effect[IO]) {
    const executingContext = {
      effectId,
      task,
      taskContext,
      mainTask,
      taskQueue,
      digestEffect,
      resolvePromise,
      resolveIterator,
    }
    const effectRunner = effectRunnerMap[effect.type]
    effectRunner(env, effect.payload, currCb, executingContext)
  } else {
    // anything else returned as is
    currCb(effect)
  }
}
```

Unlike #1524, in this PR, I just move all the effect runners into a separated file. This PR has NO new features or breaking changes, it is just an internal refactor.