### PR TITLE
Extract forkQueue and newTask to separated files

### DIFF
--- a/packages/core/src/internal/forkQueue.js
+++ b/packages/core/src/internal/forkQueue.js
@@ -1,0 +1,75 @@
+import { noop, remove } from './utils'
+
+/**
+ Used to track a parent task and its forks
+ In the fork model, forked tasks are attached by default to their parent
+ We model this using the concept of Parent task && main Task
+ main task is the main flow of the current Generator, the parent tasks is the
+ aggregation of the main tasks + all its forked tasks.
+ Thus the whole model represents an execution tree with multiple branches (vs the
+ linear execution tree in sequential (non parallel) programming)
+
+ A parent tasks has the following semantics
+ - It completes if all its forks either complete or all cancelled
+ - If it's cancelled, all forks are cancelled as well
+ - It aborts if any uncaught error bubbles up from forks
+ - If it completes, the return value is the one returned by the main task
+ **/
+export default function forkQueue(mainTask, onAbort, cont) {
+  let tasks = []
+  let result
+  let completed = false
+
+  addTask(mainTask)
+  const getTasks = () => tasks
+  const getTaskNames = () => tasks.map(t => t.meta.name)
+
+  function abort(err) {
+    onAbort()
+    cancelAll()
+    cont(err, true)
+  }
+
+  function addTask(task) {
+    tasks.push(task)
+    task.cont = (res, isErr) => {
+      if (completed) {
+        return
+      }
+
+      remove(tasks, task)
+      task.cont = noop
+      if (isErr) {
+        abort(res)
+      } else {
+        if (task === mainTask) {
+          result = res
+        }
+        if (!tasks.length) {
+          completed = true
+          cont(result)
+        }
+      }
+    }
+  }
+
+  function cancelAll() {
+    if (completed) {
+      return
+    }
+    completed = true
+    tasks.forEach(t => {
+      t.cont = noop
+      t.cancel()
+    })
+    tasks = []
+  }
+
+  return {
+    addTask,
+    cancelAll,
+    abort,
+    getTasks,
+    getTaskNames,
+  }
+}

--- a/packages/core/src/internal/newTask.js
+++ b/packages/core/src/internal/newTask.js
@@ -1,0 +1,128 @@
+import deferred from '@redux-saga/deferred'
+import * as is from '@redux-saga/is'
+import { TASK, TASK_CANCEL } from '@redux-saga/symbols'
+import { assignWithSymbols, check, createSetContextWarning } from './utils'
+import { addSagaStack, sagaStackToString } from './error-utils'
+import forkQueue from './forkQueue'
+
+export default function newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont) {
+  let running = true
+  let cancelled = false
+  let aborted = false
+  let taskResult
+  let taskError
+  let deferredEnd = null
+
+  const cancelledDueToErrorTasks = []
+
+  const context = Object.create(parentContext)
+  const queue = forkQueue(
+    mainTask,
+    function onAbort() {
+      cancelledDueToErrorTasks.push(...queue.getTaskNames())
+    },
+    end,
+  )
+
+  /**
+   This may be called by a parent generator to trigger/propagate cancellation
+   cancel all pending tasks (including the main task), then end the current task.
+
+   Cancellation propagates down to the whole execution tree holded by this Parent task
+   It's also propagated to all joiners of this task and their execution tree/joiners
+
+   Cancellation is noop for terminated/Cancelled tasks tasks
+   **/
+  function cancel() {
+    // We need to check both Running and Cancelled status
+    // Tasks can be Cancelled but still Running
+    if (running && !cancelled) {
+      cancelled = true
+      queue.cancelAll()
+      // Ending with a TASK_CANCEL will propagate the Cancellation to all joiners
+      end(TASK_CANCEL)
+    }
+  }
+
+  function end(result, isErr) {
+    running = false
+
+    if (!isErr) {
+      taskResult = result
+      deferredEnd && deferredEnd.resolve(result)
+    } else {
+      addSagaStack(result, {
+        meta,
+        effect: task.crashedEffect,
+        cancelledTasks: cancelledDueToErrorTasks,
+      })
+
+      if (task.isRoot) {
+        if (result && result.sagaStack) {
+          result.sagaStack = sagaStackToString(result.sagaStack)
+        }
+
+        env.onError(result)
+      }
+      taskError = result
+      aborted = true
+      deferredEnd && deferredEnd.reject(result)
+    }
+    task.cont(result, isErr)
+    task.joiners.forEach(j => j.cb(result, isErr))
+    task.joiners = null
+  }
+
+  function setContext(props) {
+    if (process.env.NODE_ENV !== 'production') {
+      check(props, is.object, createSetContextWarning('task', props))
+    }
+
+    assignWithSymbols(context, props)
+  }
+
+  function toPromise() {
+    if (deferredEnd) {
+      return deferredEnd.promise
+    }
+
+    deferredEnd = deferred()
+
+    if (!running) {
+      if (aborted) {
+        deferredEnd.reject(taskError)
+      } else {
+        deferredEnd.resolve(taskResult)
+      }
+    }
+
+    return deferredEnd.promise
+  }
+
+  const task = {
+    // fields
+    [TASK]: true,
+    id: parentEffectId,
+    mainTask,
+    meta,
+    isRoot,
+    context,
+    joiners: [],
+    queue,
+    crashedEffect: null,
+
+    // methods
+    cancel,
+    cont,
+    end,
+    setContext,
+    toPromise,
+    isRunning: () => running,
+    isCancelled: () => cancelled,
+    isAborted: () => aborted,
+    result: () => taskResult,
+    error: () => taskError,
+  }
+
+  return task
+}


### PR DESCRIPTION
Summary:

- internal refactor only, no public changes
- `forkQueue()` and `newTask()` get moved to new separated files
- The interface of `Task` and `effectRunner` gets changed

---

In this PR, I extract some of the code in `proc()` into two new files: _forkQueue.js_ and _newTask.js_. This PR is an internal refactor.

The biggest change in this PR is the interface of `Task` object:

- `task.mainTask` is added
- `task.context` is added, it is the same as the previous `taskContext`
- `task.queue` is added, it is the same as the previous `taskQueue`
- `task.cancel()` is added, it is the same as the previous `cancel()` which was defined in the `proc()`
- `task.end(result, isErr)` is added, it is the same as the previous `end()` which was defined in the `proc()`
- `task.crashedEffect` is added, which was defined in `proc()`
- `task._isRunning / task._isCancelled / task._isAborted / task._result / task._error / task._deferredEnd` gets removed, they are now defined as local variable in `newTask()`
- `cancelledDueToErrorTasks` is moved into `newTask()`

Because we can access the task-context and task-queue via the task object, the interface of effect runners can be simplified. It is now as follows:

```javascript
const executingContext = { task, digestEffect };

const effectRunner = effectRunnerMap[effect.type];
effectRunner(env, effect.payload, currCb, executingContext);
```

Seems that `effectRunner(env, task, effect.payload, currCb, digestEffect)` is a more proper interface. How do you think?

The idea behind this PR is that task-context or task-queue actually belongs to the task, so it is very natural that `.context` and `.queue` are fields of a task object. At the same time, `cancel()` and `end()` are operations to a task, so it is reasonable to write code such as `task.cancel()` or `task.end(arg, isErr)`.
