### PR TITLE
Make digestEffect accessible via task.digestEffect

### DIFF
--- a/packages/core/src/internal/newTask.js
+++ b/packages/core/src/internal/newTask.js
@@ -5,7 +5,7 @@ import { assignWithSymbols, check, createSetContextWarning } from './utils'
 import { addSagaStack, sagaStackToString } from './error-utils'
 import forkQueue from './forkQueue'
 
-export default function newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont) {
+export default function newTask(env, mainTask, digestEffect, parentContext, parentEffectId, meta, isRoot, cont) {
   let running = true
   let cancelled = false
   let aborted = false
@@ -114,6 +114,7 @@ export default function newTask(env, mainTask, parentContext, parentEffectId, me
     // methods
     cancel,
     cont,
+    digestEffect,
     end,
     setContext,
     toPromise,

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -27,12 +27,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
    Creates a new task descriptor for this generator.
    A task is the aggregation of it's mainTask and all it's forked tasks.
    **/
-  const task = newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont)
-
-  const executingContext = {
-    task,
-    digestEffect,
-  }
+  const task = newTask(env, mainTask, digestEffect, parentContext, parentEffectId, meta, isRoot, cont)
 
   /**
     cancellation of the main task. We'll simply resume the Generator with a TASK_CANCEL
@@ -137,7 +132,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
       proc(env, effect, task.context, effectId, meta, /* isRoot */ false, currCb)
     } else if (effect && effect[IO]) {
       const effectRunner = effectRunnerMap[effect.type]
-      effectRunner(env, effect.payload, currCb, executingContext)
+      effectRunner(env, task, effect.payload, currCb)
     } else {
       // anything else returned as is
       currCb(effect)


### PR DESCRIPTION
Make `digestEffect` accessible via `task.digestEffect` per https://github.com/redux-saga/redux-saga/pull/1660#discussion_r234583861, and change the interface of effectRunner to  `effectRunner(env, task, effect.payload, currCb)`

I simply pass the `digestEffect` when calling `newTask()`, there maybe better alternatives to implement the `task.digestEffect`. Just post it here so we can discuss it, feel free to change the implementation.