### PR TITLE
Unify task.status and mainTask.status

### DIFF
--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -10,6 +10,7 @@ import matcher from './matcher'
 import { asap, immediately } from './scheduler'
 import { getMetaInfo } from './error-utils'
 import { current as currentEffectId } from './uid'
+import { CANCELLED } from './task-status'
 import {
   assignWithSymbols,
   createAllStyleChildCallbacks,
@@ -304,7 +305,7 @@ function runChannelEffect(env, { pattern, buffer }, cb) {
 }
 
 function runCancelledEffect(env, data, cb, { task }) {
-  cb(task.mainTask.cancelled)
+  cb(task.mainTask.status === CANCELLED)
 }
 
 function runFlushEffect(env, channel, cb) {

--- a/packages/core/src/internal/newTask.js
+++ b/packages/core/src/internal/newTask.js
@@ -1,14 +1,10 @@
 import deferred from '@redux-saga/deferred'
 import * as is from '@redux-saga/is'
 import { TASK, TASK_CANCEL } from '@redux-saga/symbols'
+import { RUNNING, CANCELLED, ABORTED, DONE } from './task-status'
 import { assignWithSymbols, check, createSetContextWarning } from './utils'
 import { addSagaStack, sagaStackToString } from './error-utils'
 import forkQueue from './forkQueue'
-
-const RUNNING = 0
-const CANCELLED = 1
-const ABORTED = 2
-const DONE = 3
 
 export default function newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont) {
   let status = RUNNING

--- a/packages/core/src/internal/task-status.js
+++ b/packages/core/src/internal/task-status.js
@@ -1,0 +1,4 @@
+export const RUNNING = 0
+export const CANCELLED = 1
+export const ABORTED = 2
+export const DONE = 3


### PR DESCRIPTION
This PR unify `task.status` and `mainTask.status`. Like adding `task.status` in #1678, this PR Adds a `status` field on `mainTask` object. 

~~There is one new status called `CANCELLING`, which means the task/mainTask has received the TASK_CANCEL signal and is doing its cleanup logic (code in their finally block), while CANCELLED means the task/mainTask has done their cleanup logic.~~

~~The new enumeration value makes the status clearer so we could know whether the iterator is actually running after it receives a cancellation signal. However as other code does not rely on the CANCELLING status, we can merge it into the CANCELLED status. So should I merge it? how do you think about it?~~