### PR TITLE
Use jest.useFakeTimer instead of lolex.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "lerna-alias": "^3.0.2",
     "lint-staged": "^3.4.2",
     "lodash": "^4.17.10",
-    "lolex": "^1.5.2",
     "mitt": "^1.1.2",
     "normalizr": "^3.2.4",
     "npm-run-all": "^4.0.2",

--- a/packages/core/__tests__/sagaHelpers/throttle.js
+++ b/packages/core/__tests__/sagaHelpers/throttle.js
@@ -1,10 +1,11 @@
-import lolex from 'lolex'
 import sagaMiddleware, { END } from '../../src'
 import { createStore, applyMiddleware } from 'redux'
 import delayP from '@redux-saga/delay-p'
 import { take, cancel, throttle } from '../../src/effects'
+
 test('throttle', () => {
-  const clock = lolex.install()
+  jest.useFakeTimers()
+
   const actual = []
   const expected = [['a1', 'a2', 0], ['a1', 'a2', 10], ['a1', 'a2', 20], ['a1', 'a2', 30], ['a1', 'a2', 34]]
   const middleware = sagaMiddleware()
@@ -33,16 +34,16 @@ test('throttle', () => {
             payload: val,
           }),
         )
-        .then(() => clock.tick(10)), // next tick
+        .then(() => jest.advanceTimersByTime(10)), // next tick
     )
   }
 
   Promise.resolve()
-    .then(() => clock.tick(1)) // just start for the smallest tick
-    .then(() => clock.tick(10)) // tick past first delay
+    .then(() => jest.advanceTimersByTime(1)) // just start for the smallest tick
+    .then(() => jest.advanceTimersByTime(10)) // tick past first delay
 
   return dispatchedActions[34] // wait so trailing dispatch gets processed
-    .then(() => clock.tick(100))
+    .then(() => jest.advanceTimersByTime(100))
     .then(() =>
       store.dispatch({
         type: 'CANCEL_WATCHER',
@@ -58,17 +59,11 @@ test('throttle', () => {
       // throttle must ignore incoming actions during throttling interval
       expect(actual).toEqual(expected)
     })
-    .then(
-      () => {
-        clock.uninstall()
-      },
-      err => {
-        clock.uninstall()
-        throw err
-      },
-    )
 })
+
 test('throttle: pattern END', () => {
+  jest.useRealTimers()
+
   const delayMs = 20
   const middleware = sagaMiddleware()
   const store = createStore(() => ({}), {}, applyMiddleware(middleware))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,6 @@
     "bundlesize": "^0.11.0",
     "jest": "^23.5.0",
     "lerna-alias": "^3.0.2",
-    "lolex": "^1.5.2",
     "mitt": "^1.1.2",
     "rimraf": "^2.4.3",
     "rollup": "^0.65.2",


### PR DESCRIPTION
| Q                        | A  |
| ------------------------ | ---  |
| Fixed Issues?            |   |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      |   |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
Just remove lolex and use the built-in `jest.useFakeTimer`.