### PR TITLE
Add `takeLatestPerKey` and `takeLeadingPerKey` helpers

### DIFF
--- a/packages/core/__tests__/sagaHelpers/takeLatestPerKey.js
+++ b/packages/core/__tests__/sagaHelpers/takeLatestPerKey.js
@@ -1,0 +1,132 @@
+import sagaMiddleware, { END } from '../../src'
+import { createStore, applyMiddleware } from 'redux'
+import { arrayOfDeferred } from '@redux-saga/deferred'
+import { take, cancel, takeLatestPerKey } from '../../src/effects'
+test('takeLatestPerKey', () => {
+  const defs = arrayOfDeferred(6)
+  const actual = []
+  const middleware = sagaMiddleware()
+  const store = applyMiddleware(middleware)(createStore)(() => {})
+  middleware.run(root)
+
+  function selectKey(action) {
+    return action.payload.id
+  }
+
+  function* root() {
+    const task = yield takeLatestPerKey('ACTION', worker, selectKey, 'a1', 'a2')
+    yield take('CANCEL_WATCHER')
+    yield cancel(task)
+  }
+
+  function* worker(arg1, arg2, action) {
+    const idx = action.payload.data - 1
+    const response = yield defs[idx].promise
+    actual.push([arg1, arg2, response])
+  }
+
+  return Promise.resolve()
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 1,
+        },
+      })
+    })
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 2,
+        },
+      })
+    })
+    .then(() => defs[0].resolve('w-1'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 4,
+        },
+      })
+    })
+    .then(() => defs[1].resolve('w-2'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 3,
+        },
+      })
+    })
+    .then(() => defs[3].resolve('w-4'))
+    .then(() => defs[2].resolve('w-3'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 5,
+        },
+      })
+      /*
+        We immediately cancel the watcher after firing the action
+        The watcher should be cancelled after this
+        no further task should be forked
+        the last forked task should also be cancelled
+      */
+      store.dispatch({
+        type: 'CANCEL_WATCHER',
+      })
+    })
+    .then(() => defs[3].resolve('w-5'))
+    .then(() => {
+      // this one should be ignored by the watcher
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 6,
+        },
+      })
+    })
+    .then(() => {
+      // takeLatestPerKey must cancel current task before forking a new task
+      expect(actual).toEqual([['a1', 'a2', 'w-2'], ['a1', 'a2', 'w-3']])
+    })
+})
+test('takeLatestPerKey: pattern END', () => {
+  const middleware = sagaMiddleware()
+  const store = createStore(() => ({}), {}, applyMiddleware(middleware))
+  const mainTask = middleware.run(saga)
+  let task
+
+  function* saga() {
+    task = yield takeLatestPerKey('ACTION', fnToCall, () => null)
+  }
+
+  let called = false
+
+  function* fnToCall() {
+    called = true
+  }
+
+  store.dispatch(END)
+  store.dispatch({
+    type: 'ACTION',
+  })
+  store.dispatch({
+    type: 'ACTION',
+  })
+  return mainTask.toPromise().then(() => {
+    // should finish takeLatestPerKey task on END
+    expect(task.isRunning()).toBe(false) // should not call function if finished with END
+
+    expect(called).toBe(false)
+  })
+})

--- a/packages/core/__tests__/sagaHelpers/takeLeadingPerKey.js
+++ b/packages/core/__tests__/sagaHelpers/takeLeadingPerKey.js
@@ -1,0 +1,129 @@
+import sagaMiddleware, { END } from '../../src'
+import { createStore, applyMiddleware } from 'redux'
+import { arrayOfDeferred } from '@redux-saga/deferred'
+import { take, cancel, takeLeadingPerKey } from '../../src/effects'
+test('takeLeadingPerKey', () => {
+  const defs = arrayOfDeferred(6)
+  const actual = []
+  const middleware = sagaMiddleware()
+  const store = applyMiddleware(middleware)(createStore)(() => {})
+  middleware.run(root)
+
+  function selectKey(action) {
+    return action.payload.id
+  }
+
+  function* root() {
+    const task = yield takeLeadingPerKey('ACTION', worker, selectKey, 'a1', 'a2')
+    yield take('CANCEL_WATCHER')
+    yield cancel(task)
+  }
+
+  function* worker(arg1, arg2, action) {
+    const idx = action.payload.data - 1
+    const response = yield defs[idx].promise
+    actual.push([arg1, arg2, response])
+  }
+
+  return Promise.resolve()
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 1,
+        },
+      })
+    })
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 2,
+        },
+      })
+    })
+    .then(() => defs[0].resolve('w-1'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 4,
+        },
+      })
+    })
+    .then(() => defs[1].resolve('w-2'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 3,
+        },
+      })
+    })
+    .then(() => defs[3].resolve('w-4'))
+    .then(() => defs[2].resolve('w-3'))
+    .then(() => {
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 1,
+          data: 5,
+        },
+      })
+      /*
+        We immediately cancel the watcher after firing the action
+        The watcher should be cancelled after this
+        no further task should be forked
+        the last forked task should also be cancelled
+      */
+      store.dispatch({
+        type: 'CANCEL_WATCHER',
+      })
+    })
+    .then(() => defs[3].resolve('w-5'))
+    .then(() => {
+      // this one should be ignored by the watcher
+      store.dispatch({
+        type: 'ACTION',
+        payload: {
+          id: 2,
+          data: 6,
+        },
+      })
+    })
+    .then(() => {
+      // takeLeadingPerKey must ignore new action and keep running task until the completion
+      expect(actual).toEqual([['a1', 'a2', 'w-1'], ['a1', 'a2', 'w-4']])
+    })
+})
+test('takeLeadingPerKey: pattern END', () => {
+  const middleware = sagaMiddleware()
+  const store = createStore(() => ({}), {}, applyMiddleware(middleware))
+  const mainTask = middleware.run(saga)
+  let task
+
+  function* saga() {
+    task = yield takeLeadingPerKey('ACTION', fnToCall, () => null)
+  }
+
+  let called = false
+
+  function* fnToCall() {
+    called = true
+  }
+
+  store.dispatch(END)
+  store.dispatch({
+    type: 'ACTION',
+  })
+  return mainTask.toPromise().then(() => {
+    // should finish takeLeadingPerKey task on END
+    expect(task.isRunning()).toBe(false) // should not call function if finished with END
+
+    expect(called).toBe(false)
+  })
+})

--- a/packages/core/src/effects.js
+++ b/packages/core/src/effects.js
@@ -21,7 +21,16 @@ export {
   delay,
 } from './internal/io'
 
-export { debounce, retry, takeEvery, takeLatest, takeLeading, throttle } from './internal/io-helpers'
+export {
+  debounce,
+  retry,
+  takeEvery,
+  takeLatest,
+  takeLatestPerKey,
+  takeLeading,
+  takeLeadingPerKey,
+  throttle,
+} from './internal/io-helpers'
 
 import * as effectTypes from './internal/effectTypes'
 

--- a/packages/core/src/internal/io-helpers.js
+++ b/packages/core/src/internal/io-helpers.js
@@ -4,7 +4,9 @@ import { check } from './utils'
 import {
   takeEveryHelper,
   takeLatestHelper,
+  takeLatestPerKeyHelper,
   takeLeadingHelper,
+  takeLeadingPerKeyHelper,
   throttleHelper,
   retryHelper,
   debounceHelper,
@@ -31,12 +33,28 @@ export function takeLatest(patternOrChannel, worker, ...args) {
   return fork(takeLatestHelper, patternOrChannel, worker, ...args)
 }
 
+export function takeLatestPerKey(patternOrChannel, worker, keySelector, ...args) {
+  if (process.env.NODE_ENV !== 'production') {
+    validateTakeEffect(takeLatestPerKey, patternOrChannel, worker, keySelector)
+  }
+
+  return fork(takeLatestPerKeyHelper, patternOrChannel, worker, keySelector, ...args)
+}
+
 export function takeLeading(patternOrChannel, worker, ...args) {
   if (process.env.NODE_ENV !== 'production') {
     validateTakeEffect(takeLeading, patternOrChannel, worker)
   }
 
   return fork(takeLeadingHelper, patternOrChannel, worker, ...args)
+}
+
+export function takeLeadingPerKey(patternOrChannel, worker, keySelector, ...args) {
+  if (process.env.NODE_ENV !== 'production') {
+    validateTakeEffect(takeLeadingPerKey, patternOrChannel, worker, keySelector)
+  }
+
+  return fork(takeLeadingPerKeyHelper, patternOrChannel, worker, keySelector, ...args)
 }
 
 export function throttle(ms, pattern, worker, ...args) {

--- a/packages/core/src/internal/sagaHelpers/index.js
+++ b/packages/core/src/internal/sagaHelpers/index.js
@@ -1,6 +1,8 @@
 export { default as takeEveryHelper } from './takeEvery'
 export { default as takeLatestHelper } from './takeLatest'
+export { default as takeLatestPerKeyHelper } from './takeLatestPerKey'
 export { default as takeLeadingHelper } from './takeLeading'
+export { default as takeLeadingPerKeyHelper } from './takeLeadingPerKey'
 export { default as throttleHelper } from './throttle'
 export { default as retryHelper } from './retry'
 export { default as debounceHelper } from './debounce'

--- a/packages/core/src/internal/sagaHelpers/takeLatestPerKey.js
+++ b/packages/core/src/internal/sagaHelpers/takeLatestPerKey.js
@@ -1,0 +1,37 @@
+import fsmIterator, { safeName } from './fsmIterator'
+import { call, cancel, fork, take } from '../io'
+
+export default function takeLatestPerKey(patternOrChannel, worker, keySelector, ...args) {
+  const yTake = { done: false, value: take(patternOrChannel) }
+  const yCall = ac => ({ done: false, value: call(keySelector, ac) })
+  const yFork = ac => ({ done: false, value: fork(worker, ...args, ac) })
+  const yCancel = task => ({ done: false, value: cancel(task) })
+
+  let tasks = {}
+  let action
+  let key
+  const setTask = k => t => (tasks[k] = t)
+  const setAction = ac => (action = ac)
+  const setKey = k => (key = k)
+
+  return fsmIterator(
+    {
+      q1() {
+        return { nextState: 'q2', effect: yTake, stateUpdater: setAction }
+      },
+      q2() {
+        return { nextState: 'q3', effect: yCall(action), stateUpdater: setKey }
+      },
+      q3() {
+        return tasks[key]
+          ? { nextState: 'q4', effect: yCancel(tasks[key]) }
+          : { nextState: 'q1', effect: yFork(action), stateUpdater: setTask(key) }
+      },
+      q4() {
+        return { nextState: 'q1', effect: yFork(action), stateUpdater: setTask(key) }
+      },
+    },
+    'q1',
+    `takeLatestPerKey(${safeName(patternOrChannel)}, ${worker.name}, ${keySelector.name})`,
+  )
+}

--- a/packages/core/src/internal/sagaHelpers/takeLeadingPerKey.js
+++ b/packages/core/src/internal/sagaHelpers/takeLeadingPerKey.js
@@ -1,0 +1,33 @@
+import fsmIterator, { safeName } from './fsmIterator'
+import { call, fork, take } from '../io'
+
+export default function takeLeadingPerKey(patternOrChannel, worker, keySelector, ...args) {
+  const yTake = { done: false, value: take(patternOrChannel) }
+  const yCall = ac => ({ done: false, value: call(keySelector, ac) })
+  const yFork = ac => ({ done: false, value: fork(worker, ...args, ac) })
+
+  let tasks = {}
+  let action
+  let key
+  const setTask = k => t => (tasks[k] = t)
+  const setAction = ac => (action = ac)
+  const setKey = k => (key = k)
+
+  return fsmIterator(
+    {
+      q1() {
+        return { nextState: 'q2', effect: yTake, stateUpdater: setAction }
+      },
+      q2() {
+        return { nextState: 'q3', effect: yCall(action), stateUpdater: setKey }
+      },
+      q3() {
+        return tasks[key] && tasks[key].isRunning()
+          ? { nextState: 'q2', effect: yTake, stateUpdater: setAction }
+          : { nextState: 'q1', effect: yFork(action), stateUpdater: setTask(key) }
+      },
+    },
+    'q1',
+    `takeLeadingPerKey(${safeName(patternOrChannel)}, ${worker.name}, ${keySelector.name})`,
+  )
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  Fixes #1751, Fixes #694  |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |  Yes  |
| Tests Added + Pass?      |  Yes  |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

**I created CodeSandbox examples for what I'm currently calling [`takeLatestPerKey`](https://codesandbox.io/s/kwr75ynq7v) and [`takeLeadingPerKey`](https://codesandbox.io/s/j38593lp49).**

Example usage:
`yield takeLatestPerKey("ACTION", worker, function selectId({ payload: { id } }) { return id; });`
`yield takeLeadingPerKey("ACTION", worker,  function selectId({ payload: { id } }) { return id; });`

Awhile ago, I came across the same need as described in https://github.com/redux-saga/redux-saga/issues/694. I also opened a new issue in https://github.com/redux-saga/redux-saga/issues/1751 to accompany this PR.

I borrowed the solution written by @Andarist based on `takeLatest` from the https://github.com/redux-saga/redux-saga/issues/694. It was simple enough to imagine what a similar solution based on `takeLeading` would look like. Both of these helpers take a key selector function - which takes the action that spawns the saga as a parameter and that returns a key. They then effectively scope a `takeLatest`/`takeLeading` to this key.

I'd like to contribute these helpers back to `redux-saga` as they have been very useful in the places I've worked. I hope there's interest in adding these helpers in, as I believe they would benefit many people with similar needs.