### PR TITLE
Babel-plugin dont handle empty location

### DIFF
--- a/packages/babel-plugin-redux-saga/src/index.js
+++ b/packages/babel-plugin-redux-saga/src/index.js
@@ -91,11 +91,13 @@ module.exports = function(babel) {
      *  })
      */
     FunctionDeclaration(path, state) {
-      if (!isSaga(path)) return
+      var node = path.node
+      if (!node.loc || !isSaga(path)) return
 
-      var functionName = path.node.id.name
+      var functionName = node.id.name
       var filename = getFilename(state.file.opts, state.opts.useAbsolutePath)
-      var locationData = calcLocation(path.node.loc, filename)
+
+      var locationData = calcLocation(node.loc, filename)
 
       const extendedDeclaration = createLocationExtender(t.identifier(functionName), locationData)
 
@@ -108,11 +110,11 @@ module.exports = function(babel) {
     },
     FunctionExpression(path, state) {
       var node = path.node
-
-      if (!isSaga(path) || alreadyVisited.has(node)) return
+      if (!node.loc || !isSaga(path) || alreadyVisited.has(node)) return
       alreadyVisited.add(node)
 
       var filename = getFilename(state.file.opts, state.opts.useAbsolutePath)
+
       var locationData = calcLocation(node.loc, filename)
       var sourceCode = getSourceCode(path)
 
@@ -137,11 +139,11 @@ module.exports = function(babel) {
     YieldExpression(path, state) {
       var node = path.node
       var yielded = node.argument
-
       if (!node.loc || node.delegate) return
       if (!t.isCallExpression(yielded) && !t.isLogicalExpression(yielded)) return
 
       var filename = getFilename(state.file.opts, state.opts.useAbsolutePath)
+
       var locationData = calcLocation(node.loc, filename)
       var sourceCode = getSourceCode(path)
 

--- a/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel6-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel6-expected.js
@@ -1,5 +1,31 @@
 "use strict";
 
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
 var _marked =
 /*#__PURE__*/
 regeneratorRuntime.mark(test1),
@@ -60,3 +86,45 @@ Object.defineProperty(test2, "@@redux-saga/LOCATION", {
     code: null
   }
 })
+
+var Component =
+/*#__PURE__*/
+function (_React$PureComponent) {
+  _inherits(Component, _React$PureComponent);
+
+  function Component() {
+    _classCallCheck(this, Component);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Component).apply(this, arguments));
+  }
+
+  _createClass(Component, [{
+    key: "getData",
+    value:
+    /*#__PURE__*/
+    regeneratorRuntime.mark(function getData() {
+      return regeneratorRuntime.wrap(function getData$(_context3) {
+        while (1) {
+          switch (_context3.prev = _context3.next) {
+            case 0:
+              _context3.next = 2;
+              return 1;
+
+            case 2:
+            case "end":
+              return _context3.stop();
+          }
+        }
+      }, getData, this);
+    })
+  }, {
+    key: "render",
+    value: function render() {
+      var data = _toConsumableArray(this.getData());
+
+      return data;
+    }
+  }]);
+
+  return Component;
+}(React.PureComponent);

--- a/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel7-expected.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/preset-env/babel7-expected.js
@@ -1,5 +1,15 @@
 "use strict";
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var _marked = /*#__PURE__*/regeneratorRuntime.mark(test1),
     _marked2 = /*#__PURE__*/regeneratorRuntime.mark(test2);
 
@@ -47,6 +57,7 @@ function test2() {
     }
   }, _marked2, this);
 }
+
 Object.defineProperty(test2, "@@redux-saga/LOCATION", {
   value: {
     fileName: "test/fixtures/preset-env/source.js",
@@ -54,3 +65,40 @@ Object.defineProperty(test2, "@@redux-saga/LOCATION", {
     code: null
   }
 })
+
+var Component = function (_React$PureComponent) {
+  _inherits(Component, _React$PureComponent);
+
+  function Component() {
+    _classCallCheck(this, Component);
+
+    return _possibleConstructorReturn(this, (Component.__proto__ || Object.getPrototypeOf(Component)).apply(this, arguments));
+  }
+
+  _createClass(Component, [{
+    key: "getData",
+    value: /*#__PURE__*/regeneratorRuntime.mark(function getData() {
+      return regeneratorRuntime.wrap(function getData$(_context3) {
+        while (1) {
+          switch (_context3.prev = _context3.next) {
+            case 0:
+              _context3.next = 2;
+              return 1;
+
+            case 2:
+            case "end":
+              return _context3.stop();
+          }
+        }
+      }, getData, this);
+    })
+  }, {
+    key: "render",
+    value: function render() {
+      var data = [].concat(_toConsumableArray(this.getData()));
+      return data;
+    }
+  }]);
+
+  return Component;
+}(React.PureComponent);

--- a/packages/babel-plugin-redux-saga/test/fixtures/preset-env/source.js
+++ b/packages/babel-plugin-redux-saga/test/fixtures/preset-env/source.js
@@ -5,3 +5,13 @@ function* test1() {
 function* test2() {
   yield 2
 }
+
+class Component extends React.PureComponent {
+  *getData() {
+    yield 1
+  }
+  render() {
+    const data = [...this.getData()]
+    return data
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | https://github.com/redux-saga/redux-saga/issues/1742 |
| Patch: Bug Fix?          |  bug fix  |
| Major: Breaking Change?  |  no  |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

`FunctionExpression` didn't have empty location check (when code is not part of original code, but generated by other babel-plugins) so I added
