### PR TITLE
Handle undefined values and prevent infinite loops

### DIFF
--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -163,7 +163,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
     // Completion callback passed to the appropriate effect runner
     function currCb(res, isErr) {
-      if (effectSettled) {
+      if (effectSettled || res === undefined) {
         return
       }
 

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -163,7 +163,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
 
     // Completion callback passed to the appropriate effect runner
     function currCb(res, isErr) {
-      if (effectSettled || res === undefined) {
+      if (effectSettled) {
         return
       }
 
@@ -177,7 +177,7 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
         }
       }
 
-      if (isErr) {
+      if (isErr || res === undefined) {
         sagaError.setCrashedEffect(effect)
       }
 


### PR DESCRIPTION
Fixes #1750.

This slight change prevents the code from entering an infinite loop and causing the browser to freeze. This behavior is currently triggered by returning effects (Promises) that resolve to `Promise.resolve()` or `Promise.reject()`. The resulting value of these calls is `undefined`. This change accounts for that and terminates the call stack, preventing the infinite loop.