### PR TITLE
Fix endless loop while createTaskIterator gets a function that return…

### DIFF
--- a/packages/core/__tests__/interpreter/fork.js
+++ b/packages/core/__tests__/interpreter/fork.js
@@ -19,6 +19,7 @@ test('should not interpret returned effect. fork(() => effectCreator())', () => 
       expect(actual).toEqual(io.call(fn))
     })
 })
+
 test("should not interpret returned effect. yield fork(takeEvery, 'pattern', fn)", () => {
   const middleware = sagaMiddleware()
   createStore(() => ({}), {}, applyMiddleware(middleware))
@@ -53,6 +54,24 @@ test('should interpret returned promise. fork(() => promise)', () => {
       expect(actual).toEqual('a')
     })
 })
+
+test('should handle promise that resolves undefined properly. fork(() => Promise.resolve(undefined))', () => {
+  const middleware = sagaMiddleware()
+  createStore(() => ({}), {}, applyMiddleware(middleware))
+
+  function* genFn() {
+    const task = yield io.fork(() => Promise.resolve(undefined))
+    return task.toPromise()
+  }
+
+  return middleware
+    .run(genFn)
+    .toPromise()
+    .then(actual => {
+      expect(actual).toEqual(undefined)
+    })
+})
+
 test('should interpret returned iterator. fork(() => iterator)', () => {
   const middleware = sagaMiddleware()
   createStore(() => ({}), {}, applyMiddleware(middleware))

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -37,10 +37,17 @@ function createTaskIterator({ context, fn, args }) {
       return result
     }
 
-    const next = (value = result) => ({
-      value,
-      done: !is.promise(value),
-    })
+    let resolved = false
+
+    const next = arg => {
+      if (!resolved) {
+        resolved = true
+        // Only promises returned from fork will be interpreted. See #1573
+        return { value: result, done: !is.promise(result) }
+      } else {
+        return { value: arg, done: true }
+      }
+    }
 
     return makeIterator(next)
   } catch (err) {


### PR DESCRIPTION
…s a Promise resolved with undefined.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #1750 |
| Patch: Bug Fix?          |  👍  |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
In the previous implementation, if the function passed to `createTaskIterator` returns a promise which resolves to be undefined, the iterator created by `createTaskIterator` will lead to an endless loop.

In the PR, I use `let resolved = false` to make sure that the promise is interpreted at most once.
