### PR TITLE
Bug Fixed ValidEffect in @redux-saga/types

### DIFF
--- a/packages/is/index.d.ts
+++ b/packages/is/index.d.ts
@@ -1,9 +1,9 @@
-import { ActionPattern, Buffer, Channel, GuardPredicate, Pattern, Task, ValidEffect } from '@redux-saga/types'
+import { ActionPattern, Buffer, Channel, GuardPredicate, Pattern, Task, Effect } from '@redux-saga/types'
 
 export const array: GuardPredicate<Array<any>>
 export const buffer: GuardPredicate<Buffer<any>>
 export const channel: GuardPredicate<Channel<any>>
-export const effect: GuardPredicate<ValidEffect>
+export const effect: GuardPredicate<Effect>
 export const func: GuardPredicate<Function>
 export const iterable: GuardPredicate<Iterable<any>>
 export const iterator: GuardPredicate<Iterator<any>>


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed PR?            | `Fixes #1655` <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | No |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

Variable `ValidEffect` might not be defined in `@redux-saga/types`, so it caused an import error as using TypeScript.  

I wonder if another way, fix `import { Effect } from '@redux-saga/types'` in `is/index.d.ts`, might be better.