### PR TITLE
typings: better inference of action types from action pattern

### DIFF
--- a/packages/core/__tests__/typescript/effects.ts
+++ b/packages/core/__tests__/typescript/effects.ts
@@ -28,6 +28,7 @@ import {
   debounce,
 } from 'redux-saga/effects'
 import { Action, ActionCreator } from 'redux'
+import { StringableActionCreator, ActionMatchingPattern } from '@redux-saga/types'
 
 interface MyAction extends Action {
   customField: string
@@ -783,6 +784,37 @@ function* testTakeEvery(): SagaIterator {
     ['my-action', (action: Action) => action.type === 'my-action', stringableActionCreator, isMyAction],
     (action: Action) => {},
   )
+
+  // test inference of action types from action pattern
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield takeEvery([pattern1, pattern2], action => {
+    if (action.type === 'A') {
+    }
+
+    if (action.type === 'B') {
+    }
+
+    // typings:expect-error
+    if (action.type === 'C') {
+    }
+  })
+  yield takeEvery(
+    [pattern1, pattern2],
+    (arg: { foo: string }, action: ActionMatchingPattern<typeof pattern1 | typeof pattern2>) => {
+      if (action.type === 'A') {
+      }
+
+      if (action.type === 'B') {
+      }
+
+      // typings:expect-error
+      if (action.type === 'C') {
+      }
+    },
+    { foo: 'bar' },
+  )
 }
 
 function* testChannelTakeEvery(): SagaIterator {
@@ -901,6 +933,37 @@ function* testTakeLatest(): SagaIterator {
     ['my-action', (action: Action) => action.type === 'my-action', stringableActionCreator, isMyAction],
     (action: Action) => {},
   )
+
+  // test inference of action types from action pattern
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield takeLatest([pattern1, pattern2], action => {
+    if (action.type === 'A') {
+    }
+
+    if (action.type === 'B') {
+    }
+
+    // typings:expect-error
+    if (action.type === 'C') {
+    }
+  })
+  yield takeLatest(
+    [pattern1, pattern2],
+    (arg: { foo: string }, action: ActionMatchingPattern<typeof pattern1 | typeof pattern2>) => {
+      if (action.type === 'A') {
+      }
+
+      if (action.type === 'B') {
+      }
+
+      // typings:expect-error
+      if (action.type === 'C') {
+      }
+    },
+    { foo: 'bar' },
+  )
 }
 
 function* testChannelTakeLatest(): SagaIterator {
@@ -1018,6 +1081,37 @@ function* testTakeLeading(): SagaIterator {
   yield takeLeading(
     ['my-action', (action: Action) => action.type === 'my-action', stringableActionCreator, isMyAction],
     (action: Action) => {},
+  )
+
+  // test inference of action types from action pattern
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield takeLeading([pattern1, pattern2], action => {
+    if (action.type === 'A') {
+    }
+
+    if (action.type === 'B') {
+    }
+
+    // typings:expect-error
+    if (action.type === 'C') {
+    }
+  })
+  yield takeLeading(
+    [pattern1, pattern2],
+    (arg: { foo: string }, action: ActionMatchingPattern<typeof pattern1 | typeof pattern2>) => {
+      if (action.type === 'A') {
+      }
+
+      if (action.type === 'B') {
+      }
+
+      // typings:expect-error
+      if (action.type === 'C') {
+      }
+    },
+    { foo: 'bar' },
   )
 }
 
@@ -1140,6 +1234,38 @@ function* testThrottle(): SagaIterator {
     ['my-action', (action: Action) => action.type === 'my-action', stringableActionCreator, isMyAction],
     (action: Action) => {},
   )
+
+  // test inference of action types from action pattern
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield throttle(1, [pattern1, pattern2], action => {
+    if (action.type === 'A') {
+    }
+
+    if (action.type === 'B') {
+    }
+
+    // typings:expect-error
+    if (action.type === 'C') {
+    }
+  })
+  yield throttle(
+    1,
+    [pattern1, pattern2],
+    (arg: { foo: string }, action: ActionMatchingPattern<typeof pattern1 | typeof pattern2>) => {
+      if (action.type === 'A') {
+      }
+
+      if (action.type === 'B') {
+      }
+
+      // typings:expect-error
+      if (action.type === 'C') {
+      }
+    },
+    { foo: 'bar' },
+  )
 }
 
 function* testChannelThrottle(): SagaIterator {
@@ -1260,6 +1386,38 @@ function* testDebounce(): SagaIterator {
     1,
     ['my-action', (action: Action) => action.type === 'my-action', stringableActionCreator, isMyAction],
     (action: Action) => {},
+  )
+
+  // test inference of action types from action pattern
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield debounce(1, [pattern1, pattern2], action => {
+    if (action.type === 'A') {
+    }
+
+    if (action.type === 'B') {
+    }
+
+    // typings:expect-error
+    if (action.type === 'C') {
+    }
+  })
+  yield debounce(
+    1,
+    [pattern1, pattern2],
+    (arg: { foo: string }, action: ActionMatchingPattern<typeof pattern1 | typeof pattern2>) => {
+      if (action.type === 'A') {
+      }
+
+      if (action.type === 'B') {
+      }
+
+      // typings:expect-error
+      if (action.type === 'C') {
+      }
+    },
+    { foo: 'bar' },
   )
 }
 

--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -1,5 +1,5 @@
 import { Action, AnyAction } from 'redux'
-import {Last, Reverse} from 'typescript-tuple'
+import { Last, Reverse } from 'typescript-tuple'
 
 import {
   ActionPattern,
@@ -13,6 +13,7 @@ import {
   Predicate,
   Task,
   StrictEffect,
+  ActionMatchingPattern,
 } from '@redux-saga/types'
 
 import { FlushableChannel, PuttableChannel, TakeableChannel } from './index'
@@ -173,11 +174,20 @@ export interface ChannelTakeEffectDescriptor<T> {
  *   the incoming action to the argument list (i.e. the action will be the last
  *   argument provided to `saga`)
  */
+export function takeEvery<P extends ActionPattern>(
+  pattern: P,
+  worker: (action: ActionMatchingPattern<P>) => any,
+): ForkEffect
+export function takeEvery<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect
 export function takeEvery<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
 export function takeEvery<A extends Action, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
-  ...args: AllButLast<Parameters<Fn>>
+  ...args: HelperWorkerParameters<A, Fn>
 ): ForkEffect
 
 /**
@@ -242,6 +252,15 @@ export function takeEvery<T, Fn extends (...args: any[]) => any>(
  *   the incoming action to the argument list (i.e. the action will be the last
  *   argument provided to `saga`)
  */
+export function takeLatest<P extends ActionPattern>(
+  pattern: P,
+  worker: (action: ActionMatchingPattern<P>) => any,
+): ForkEffect
+export function takeLatest<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect
 export function takeLatest<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
 export function takeLatest<A extends Action, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
@@ -305,6 +324,15 @@ export function takeLatest<T, Fn extends (...args: any[]) => any>(
  *   add the incoming action to the argument list (i.e. the action will be the
  *   last argument provided to `saga`)
  */
+export function takeLeading<P extends ActionPattern>(
+  pattern: P,
+  worker: (action: ActionMatchingPattern<P>) => any,
+): ForkEffect
+export function takeLeading<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect
 export function takeLeading<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
 export function takeLeading<A extends Action, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
@@ -1051,6 +1079,17 @@ export function delay<T = true>(ms: number, val?: T): CallEffect
  *   the incoming action to the argument list (i.e. the action will be the last
  *   argument provided to `saga`)
  */
+export function throttle<P extends ActionPattern>(
+  ms: number,
+  pattern: P,
+  worker: (action: ActionMatchingPattern<P>) => any,
+): ForkEffect
+export function throttle<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  ms: number,
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect
 export function throttle<A extends Action>(
   ms: number,
   pattern: ActionPattern<A>,
@@ -1131,6 +1170,17 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
  *   the incoming action to the argument list (i.e. the action will be the last
  *   argument provided to `saga`)
  */
+export function debounce<P extends ActionPattern>(
+  ms: number,
+  pattern: P,
+  worker: (action: ActionMatchingPattern<P>) => any,
+): ForkEffect
+export function debounce<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+  ms: number,
+  pattern: P,
+  worker: Fn,
+  ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+): ForkEffect
 export function debounce<A extends Action>(
   ms: number,
   pattern: ActionPattern<A>,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -31,6 +31,14 @@ export type ActionSubPattern<Guard extends Action = Action> =
 
 export type ActionPattern<Guard extends Action = Action> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]
 
+export type ActionMatchingPattern<P extends ActionPattern> = P extends ActionSubPattern
+  ? ActionMatchingSubPattern<P>
+  : P extends ActionSubPattern[] ? ActionMatchingSubPattern<P[number]> : never
+
+export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends GuardPredicate<infer A, Action>
+  ? A
+  : P extends StringableActionCreator<infer A> ? A : Action
+
 /**
  * Used to implement the buffering strategy for a channel. The Buffer interface
  * defines 3 methods: `isEmpty`, `put` and `take`


### PR DESCRIPTION
Fixes #1740.

This PR adds a new type

```ts
type ActionMatchingPattern<P extends ActionPattern>
```

that calculates matched action types (a union) given action pattern, which may be an array of stringable action creators or predicates.

This type is then used in additional overloads for `takeEvery`, `takeLatest`, `takeLeading` as well as `throttle` and `debounce` that support inferring action types and avoid the need to specify them explicitly.