### PR TITLE
fix link in API docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1001,7 +1001,7 @@ function* mySaga() {
 
 ### `all(effects)`
 
-The same as [`all([...effects])`](#alleffects-parallel-effects) but lets you to pass in a dictionary object of effects with labels, just like [`race(effects)`](#alleffects)
+The same as [`all([...effects])`](#alleffects-parallel-effects) but lets you to pass in a dictionary object of effects with labels, just like [`race(effects)`](#raceeffects)
 
 - `effects: Object` - a dictionary Object of the form {label: effect, ...}
 


### PR DESCRIPTION
`race(effects)` link pointed at `#alleffects`.