### PR TITLE
Fix 'handel' typo in api docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -819,7 +819,7 @@ const throttle = (ms, pattern, task, ...args) => fork(function*() {
 ```
 
 ### `throttle(ms, channel, saga, ...args)`
-You can also handel a channel as argument and the behaviour is the same as [`throttle(ms, pattern, saga, ..args)`](#throttlems-pattern-saga-args)
+You can also handle a channel as argument and the behaviour is the same as [`throttle(ms, pattern, saga, ..args)`](#throttlems-pattern-saga-args)
 
 ### `debounce(ms, pattern, saga, ...args)`
 
@@ -879,7 +879,7 @@ const debounce = (ms, pattern, task, ...args) => fork(function*() {
 ```
 
 ### `debounce(ms, channel, saga, ...args)`
-You can also handel a channel as argument and the behaviour is the same as [`debounce(ms, pattern, saga, ..args)`](#debouncems-pattern-saga-args)
+You can also handle a channel as argument and the behaviour is the same as [`debounce(ms, pattern, saga, ..args)`](#debouncems-pattern-saga-args)
 
 ### `retry(maxTries, delay, fn, ...args)`
 Creates an Effect description that instructs the middleware to call the function `fn` with `args` as arguments.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  n/a  |
| Patch: Bug Fix?          |  n/a  |
| Major: Breaking Change?  |  no  |
| Minor: New Feature?      |  no  |
| Tests Added + Pass?      |  n/a  |
| Any Dependency Changes?  |  no  |

<!-- Describe your changes below in as much detail as possible -->
Two simple typo fixes in api's README.
