### PR TITLE
Prevent cancellation of ended joined tasks

### DIFF
--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -178,7 +178,7 @@ function runJoinEffect(env, taskOrTasks, cb, { task }) {
     if (taskToJoin.isRunning()) {
       const joiner = { task, cb }
       cb.cancel = () => {
-        remove(taskToJoin.joiners, joiner)
+        if (taskToJoin.isRunning()) remove(taskToJoin.joiners, joiner)
       }
       taskToJoin.joiners.push(joiner)
     } else {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |    |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |  No  |

Cancelling a join task caused all nested forked tasks to be cancelled as
well, regardless of their status. This means an finished/ended forked
task was cancelled unnecessarily.

Because the `joiners` property is changed from an array to `null` when the task is ended, the
subsequent cancellation that tries to remove the joiner from `joiners` caused a `Cannot read property 'indexOf' of null` error.

We added a guard in the cancel callback that ensures the task is
running.

We wonder if the joiners property should be reset to `[]` instead of
`null`. It's another way of fixing this issue.
