### PR TITLE
typings: fix `take` typings for array of heterogeneous action creators

### DIFF
--- a/packages/core/__tests__/typescript/effects.ts
+++ b/packages/core/__tests__/typescript/effects.ts
@@ -81,6 +81,12 @@ function* testTake(): SagaIterator {
   // typings:expect-error
   yield take(multicastChannel, (input: { someField: number }) => input.someField === 'foo')
   yield take(multicastChannel, (input: ChannelItem) => input.someField === 'foo')
+
+  const pattern1: StringableActionCreator<{ type: 'A' }> = null!
+  const pattern2: StringableActionCreator<{ type: 'B' }> = null!
+
+  yield take([pattern1, pattern2])
+  yield takeMaybe([pattern1, pattern2])
 }
 
 function* testPut(): SagaIterator {
@@ -1591,10 +1597,7 @@ function* testRace(): SagaIterator {
     named3: promise,
   })
 
-  const effectArray = [
-    call(() => {}),
-    call(() => {}),
-  ]
+  const effectArray = [call(() => {}), call(() => {})]
   yield race([...effectArray])
   // typings:expect-error
   yield race([...effectArray, promise])
@@ -1619,10 +1622,7 @@ function* testNonStrictRace() {
     named3: promise,
   })
 
-  const effectArray = [
-    call(() => {}),
-    call(() => {}),
-  ]
+  const effectArray = [call(() => {}), call(() => {})]
   yield race([...effectArray])
   yield race([...effectArray, promise])
 }

--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -73,6 +73,7 @@ export const effectTypes: {
  * which are still running, it will wait for all the child tasks to terminate
  * before terminating the Task.
  */
+export function take(pattern?: ActionPattern): TakeEffect
 export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
 
 /**
@@ -93,6 +94,7 @@ export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
  * internally all `dispatch`ed actions are going through the `stdChannel` which
  * is getting closed when `dispatch(END)` happens
  */
+export function takeMaybe(pattern?: ActionPattern): TakeEffect
 export function takeMaybe<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
 
 export type TakeEffect = SimpleEffect<'TAKE', TakeEffectDescriptor>
@@ -550,9 +552,7 @@ export function cps<Ctx, Fn extends (this: Ctx, ...args: any[]) => void>(
   ...args: CpsFunctionParameters<Fn>
 ): CpsEffect
 
-export type CpsFunctionParameters<Fn extends (...args: any[]) => any> = Last<
-  Parameters<Fn>
-> extends CpsCallback<any>
+export type CpsFunctionParameters<Fn extends (...args: any[]) => any> = Last<Parameters<Fn>> extends CpsCallback<any>
   ? AllButLast<Parameters<Fn>>
   : never
 
@@ -1327,10 +1327,10 @@ export type RaceEffect<T> = CombinatorEffect<'RACE', T>
 export type RaceEffectDescriptor<T> = CombinatorEffectDescriptor<T>
 
 /**
-* [H, ...T] -> T
-*/
+ * [H, ...T] -> T
+ */
 export type Tail<L extends any[]> = ((...l: L) => any) extends ((h: any, ...t: infer T) => any) ? T : never
 /**
-   * [...A, B] -> A
-   */
+ * [...A, B] -> A
+ */
 export type AllButLast<L extends any[]> = Reverse<Tail<Reverse<L>>>


### PR DESCRIPTION
Fixes https://github.com/redux-saga/redux-saga/issues/1740#issuecomment-467167529

https://github.com/redux-saga/redux-saga/pull/1769 only fixed `takeEvery` et al. But TS still got confused on similar usage of `take`.