### PR TITLE
Add cancel function to the object returned by createMockTask

### DIFF
--- a/packages/testing-utils/src/index.js
+++ b/packages/testing-utils/src/index.js
@@ -28,6 +28,7 @@ export function createMockTask() {
     isRunning: () => _isRunning,
     result: () => _result,
     error: () => _error,
+    cancel: () => {},
 
     setRunning: b => (_isRunning = b),
     setResult: r => (_result = r),


### PR DESCRIPTION
| Q                        | A |
| ------------------------ | ---  |
| Fixed Issues?            | No |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  | No   |

The object returned by createMockTask does not have a `cancel` function:
https://github.com/redux-saga/redux-saga/blob/master/packages/testing-utils/src/index.js#L21

which is part of the Task interface:
https://github.com/redux-saga/redux-saga/blob/master/packages/types/index.d.ts#L171

When testing a saga like
```
function* mySaga() {
  const task = yield takeEvery('START_TASK');
  yield take('CANCEL_TASK');
  yield cancel(task);
}
```

With a test like:
```
const mockTask = createMockTask();
// uses redux-saga-test-plan for expectSaga
return expectSaga(mySaga).provide([
  [takeEvery('START_TASK'), mockTask]  // return the mock task on 'START_TASK' action
]).dispatch({
  type: 'START_TASK'  // start the task
}).dispatch({
  type: 'CANCEL_TASK'   // cancel the task
}).run()
```
I am seeing an error reported:
`TypeError: taskToCancel.cancel is not a function`

Which seems like the object returned by createMockTask just needs to add a `cancel` method.