### PR TITLE
Update HelperWorkerParameters to match saga that don't use action

### DIFF
--- a/packages/core/__tests__/typescript/effects.ts
+++ b/packages/core/__tests__/typescript/effects.ts
@@ -754,6 +754,14 @@ function* testTakeEvery(): SagaIterator {
   yield takeEvery('my-action', helperWorker7, 'a', 'b', 'c', 'd', 'e', 'f')
   yield takeEvery('my-action', helperWorker7, 'a', 'b', 'c', 'd', 'e', 'f', 'g')
 
+  const helperWorker8 = (a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g') => {}
+
+  // typings:expect-error
+  yield takeEvery('my-action', helperWorker8, 1, 'b', 'c', 'd', 'e', 'f', 'g')
+  // typings:expect-error
+  yield takeEvery('my-action', helperWorker8, 'a', 'b', 'c', 'd', 'e', 'f')
+  yield takeEvery('my-action', helperWorker8, 'a', 'b', 'c', 'd', 'e', 'f', 'g')
+
   function* helperSaga7(a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', action: MyAction): SagaIterator {}
 
   // typings:expect-error

--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -355,7 +355,7 @@ export function takeLeading<T, Fn extends (...args: any[]) => any>(
 
 export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last<Parameters<Fn>> extends T
   ? AllButLast<Parameters<Fn>>
-  : never
+  : Parameters<Fn>
 
 /**
  * Creates an Effect description that instructs the middleware to dispatch an


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | ∅ |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | No |
| Any Dependency Changes?  | No  |

This is a fix on `HelperWorkerParameters`  type helper that is used with `takeEvery`, `takeLatest`, ... effects.

Before this fix : 

```ts
function* sagaUsingAction(
  arg1: string,
  action: ReduxAction,
) {
  console.log(arg1, action);
}

// no problem here because sagaUsingAction use the action as parameter 2
yield takeEvery( 
   'TEST_ACTION_TYPE_1',
   sagaUsingAction,
   'my arg 1',
);

function* sagaNotUsingAction(
 arg1: string,
) {
  console.log(arg1);
}

// problem here
// Argument of type '"TEST_ACTION_TYPE_2"' is not  assignable to parameter of type 'TakeableChannel<{}>'
yield takeEvery(                
   'TEST_ACTION_TYPE_2', 
   sagaNotUsingAction,
   'my arg 1',
);
```

Because the `HelperWorkerParameters` assume we always use `action` in our saga, TS does find a good definition to use for `takeEvery`.