### PR TITLE
Fix error in docs: rootSaga pattern code example

### DIFF
--- a/docs/advanced/RootSaga.md
+++ b/docs/advanced/RootSaga.md
@@ -95,7 +95,7 @@ function* rootSaga () {
     saga3,
   ];
 
-  yield sagas.map(saga =>
+  yield all(sagas.map(saga =>
     spawn(function* () {
       while (true) {
         try {
@@ -105,7 +105,7 @@ function* rootSaga () {
           console.log(e)
         }
       }
-    })
+    }))
   );
 }
 ```


### PR DESCRIPTION
Fixing a small typo in the code example for rootSaga patterns. Also pointed out by another user [here](https://github.com/redux-saga/redux-saga/issues/570#issuecomment-494226029). The array of sagas needs to be passed to an `all` which is missing in the docs.

Without the `all`, none of the saga watchers are running, but there are no errors either, so a beginner wouldn't know what's going wrong.