### PR TITLE
Export CombinatorEffect, CombinatorEffectDescriptor

### DIFF
--- a/packages/core/effects.d.ts
+++ b/packages/core/effects.d.ts
@@ -18,7 +18,7 @@ import {
 
 import { FlushableChannel, PuttableChannel, TakeableChannel } from './index'
 
-export { ActionPattern, Effect, Pattern, SimpleEffect, StrictEffect }
+export { ActionPattern, CombinatorEffect, CombinatorEffectDescriptor, Effect, Pattern, SimpleEffect, StrictEffect }
 
 export const effectTypes: {
   TAKE: 'TAKE'


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  |
| Patch: Bug Fix?          |  Downstream libraries using `redux-saga` and exporting sagas require these two types to define the type of the export. Without this type, Typescript complains that the type is not portable because it relies on the reference to this library.   |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      |  |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
