### PR TITLE
Fix take(predicate) TypeScript error

### DIFF
--- a/packages/core/__tests__/typescript/effects.ts
+++ b/packages/core/__tests__/typescript/effects.ts
@@ -42,8 +42,8 @@ Object.assign(stringableActionCreator, {
   },
 })
 
-const isMyAction = (action: Action): action is MyAction => {
-  return action.type === 'my-action'
+const isMyAction = (action: MyAction) => {
+  return action.type === 'my-action' && action.customField === 'custom-field'
 }
 
 type ChannelItem = { someField: string }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -26,7 +26,7 @@ export type Pattern<T> = SubPattern<T> | SubPattern<T>[]
 export type ActionSubPattern<Guard extends Action = Action> =
   | GuardPredicate<Guard, Action>
   | StringableActionCreator<Guard>
-  | Predicate<Action>
+  | Predicate<Guard>
   | ActionType
 
 export type ActionPattern<Guard extends Action = Action> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #1871 <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?          | 👍 |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | 👍 |
| Any Dependency Changes?  |    

### Discussion

- [ ] The `take(isMyAction)` test was updated to use an actions union in hopes to match a use-case more similar to that in the real-world.
- [x] The `ActionSubPattern` type definition was updated/corrected to allow the test to pass.

I must admit, I am pretty new to TypeScript, so any comments, suggestions and insight into the greater impact of these changes will be greatly appreciated.

cc: @Andarist, @vasilii-kovalev, @osoftware, @aikoven