### PR TITLE
do not attach cancel functions on noop

### DIFF
--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -155,7 +155,7 @@ function runForkEffect(env, { context, fn, args, detached }, cb, { task: parent 
   const meta = getIteratorMetaInfo(taskIterator, fn)
 
   immediately(() => {
-    const child = proc(env, taskIterator, parent.context, currentEffectId, meta, detached, noop)
+    const child = proc(env, taskIterator, parent.context, currentEffectId, meta, detached, undefined)
 
     if (detached) {
       cb(child)

--- a/packages/core/src/internal/newTask.js
+++ b/packages/core/src/internal/newTask.js
@@ -2,11 +2,11 @@ import deferred from '@redux-saga/deferred'
 import * as is from '@redux-saga/is'
 import { TASK, TASK_CANCEL } from '@redux-saga/symbols'
 import { RUNNING, CANCELLED, ABORTED, DONE } from './task-status'
-import { assignWithSymbols, check, createSetContextWarning } from './utils'
+import { assignWithSymbols, check, createSetContextWarning, noop } from './utils'
 import forkQueue from './forkQueue'
 import * as sagaError from './sagaError'
 
-export default function newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont) {
+export default function newTask(env, mainTask, parentContext, parentEffectId, meta, isRoot, cont = noop) {
   let status = RUNNING
   let taskResult
   let taskError

--- a/packages/core/src/internal/proc.js
+++ b/packages/core/src/internal/proc.js
@@ -50,7 +50,9 @@ export default function proc(env, iterator, parentContext, parentEffectId, meta,
     attaches cancellation logic to this task's continuation
     this will permit cancellation to propagate down the call chain
   **/
-  cont.cancel = task.cancel
+  if (cont) {
+    cont.cancel = task.cancel
+  }
 
   // kicks up the generator
   next()

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -79,7 +79,7 @@ export function runSaga(
   }
 
   return immediately(() => {
-    const task = proc(env, iterator, context, effectId, getMetaInfo(saga), /* isRoot */ true, noop)
+    const task = proc(env, iterator, context, effectId, getMetaInfo(saga), /* isRoot */ true, undefined)
 
     if (sagaMonitor) {
       sagaMonitor.effectResolved(effectId, task)

--- a/packages/core/src/internal/utils.js
+++ b/packages/core/src/internal/utils.js
@@ -5,7 +5,19 @@ import { SAGA_LOCATION, SAGA_ACTION, TASK_CANCEL, TERMINATE } from '@redux-saga/
 export const konst = v => () => v
 export const kTrue = konst(true)
 export const kFalse = konst(false)
-export const noop = () => {}
+
+let noop = () => {}
+
+if (process.env.NODE_ENV !== 'production' && typeof Proxy !== 'undefined') {
+  noop = new Proxy(noop, {
+    set: () => {
+      throw internalErr('There was an attempt to assign a property to internal `noop` function.')
+    },
+  })
+}
+
+export { noop }
+
 export const identity = v => v
 
 const hasSymbol = typeof Symbol === 'function'


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  |
| Patch: Bug Fix?          |  👍  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |  No  |

<!-- Describe your changes below in as much detail as possible -->
Hi! I'm testing the library for memory retention. I've found that if the continuation function is `noop`, it attaches the task's `cancel` function to it. Because `noop` is kind of a library global method, it will never be GC'd, leaving the cancel in memory with the iterator and the action in its context. This could lead to having unnecessary sensitive data in memory.