### PR TITLE
Fixed object type checker function definition

### DIFF
--- a/packages/is/src/index.js
+++ b/packages/is/src/index.js
@@ -6,7 +6,7 @@ export const func = f => typeof f === 'function'
 export const number = n => typeof n === 'number'
 export const string = s => typeof s === 'string'
 export const array = Array.isArray
-export const object = obj => obj && !array(obj) && typeof obj === 'object'
+export const object = obj => obj && !array(obj) && typeof obj === 'object' && obj !== null
 export const promise = p => p && func(p.then)
 export const iterator = it => it && func(it.next) && func(it.throw)
 export const iterable = it => (it && func(Symbol) ? func(it[Symbol.iterator]) : array(it))


### PR DESCRIPTION
There is an older bug in ECMA script that it treats null as an object which we should generally exclude if we really want a particular data to be real javascript object. In this PR, I've just put one more check of not null in object type checker function.

