### PR TITLE
actionChannel uses a fixed-size buffer (not unlimited)

### DIFF
--- a/docs/advanced/Channels.md
+++ b/docs/advanced/Channels.md
@@ -58,7 +58,7 @@ Next is the `yield take(requestChan)`. Besides usage with a `pattern` to take sp
 
 The important thing to note is how we're using a blocking `call`. The Saga will remain blocked until `call(handleRequest)` returns. But meanwhile, if other `REQUEST` actions are dispatched while the Saga is still blocked, they will queued internally by `requestChan`. When the Saga resumes from `call(handleRequest)` and executes the next `yield take(requestChan)`, the take will resolve with the queued message.
 
-By default, `actionChannel` buffers all incoming messages without limit. If you want a more control over the buffering, you can supply a Buffer argument to the effect creator. Redux-Saga provides some common buffers (none, dropping, sliding) but you can also supply your own buffer implementation. [See API docs](../api#buffers) for more details.
+By default, `actionChannel` buffers all incoming messages using a fixed-size buffer (limit: 10 messages). If you want a more control over the buffering, you can supply a Buffer argument to the effect creator. Redux-Saga provides some common buffers (none, dropping, sliding) but you can also supply your own buffer implementation. [See API docs](../api#buffers) for more details.
 
 For example if you want to handle only the most recent five items you can use:
 


### PR DESCRIPTION
The documentation says that `actionChannel` buffers all incoming messages without limit. However, it seems that the default buffer has capacity for 10 elements. See https://gist.github.com/tlaitinen/5b46cb63b89883ccce805c5e2dc6cb59 for steps to reproduce a buffer overflow.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
