### PR TITLE
Add localhost URL to docs for previewing the output

### DIFF
--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -25,6 +25,8 @@ To start the application, run:
 $ npm start
 ```
 
+The output will now be accessible at `http://localhost:9966`. 
+
 We are starting with the most basic use case: 2 buttons to `Increment` and `Decrement` a counter. Later, we will introduce asynchronous calls.
 
 If things go well, you should see 2 buttons `Increment` and `Decrement` along with a message below showing `Counter: 0`.


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | None |
| Patch: Bug Fix?          |  No   |
| Major: Breaking Change?  | No  |
| Minor: New Feature?      | No  |
| Tests Added + Pass?      | N/A |
| Any Dependency Changes?  | No   |

**Documentation Update**
Running `npm start` creates the following terminal output:
```
[0000] info  Server running at http://10.60.10.6:9966/ (connect)
[0001] info  LiveReload running on 35729
```
Those unfamiliar with Budo are not prompted as to where the running code can be accessed in a browser. This change lists the output URL explicitly to make it easier for beginners.
