### PR TITLE
Strong typecheck for take*, throttle and debounce effects when action…

### DIFF
--- a/.changeset/red-cherries-drop.md
+++ b/.changeset/red-cherries-drop.md
@@ -1,0 +1,6 @@
+---
+'@redux-saga/core': patch
+'@redux-saga/types': patch
+---
+
+Added strong typecheck for take\*, throttle and debounce effects if action type is provided

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -14,6 +14,7 @@ import {
   Task,
   StrictEffect,
   ActionMatchingPattern,
+  ActionType,
 } from '@redux-saga/types'
 
 import { FlushableChannel, PuttableChannel, TakeableChannel } from './index'
@@ -74,7 +75,7 @@ export const effectTypes: {
  * before terminating the Task.
  */
 export function take(pattern?: ActionPattern): TakeEffect
-export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
+export function take<A extends Action<ActionType>>(pattern?: ActionPattern<A>): TakeEffect
 
 /**
  * Same as `take(pattern)` but does not automatically terminate the Saga on an
@@ -95,7 +96,7 @@ export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
  * is getting closed when `dispatch(END)` happens
  */
 export function takeMaybe(pattern?: ActionPattern): TakeEffect
-export function takeMaybe<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
+export function takeMaybe<A extends Action<ActionType>>(pattern?: ActionPattern<A>): TakeEffect
 
 export type TakeEffect = SimpleEffect<'TAKE', TakeEffectDescriptor>
 
@@ -185,8 +186,8 @@ export function takeEvery<P extends ActionPattern, Fn extends (...args: any[]) =
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
-export function takeEvery<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
-export function takeEvery<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeEvery<A extends Action<ActionType>>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
+export function takeEvery<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -263,8 +264,8 @@ export function takeLatest<P extends ActionPattern, Fn extends (...args: any[]) 
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
-export function takeLatest<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
-export function takeLatest<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeLatest<A extends Action<ActionType>>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
+export function takeLatest<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -335,8 +336,8 @@ export function takeLeading<P extends ActionPattern, Fn extends (...args: any[])
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
-export function takeLeading<A extends Action>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
-export function takeLeading<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeLeading<A extends Action<ActionType>>(pattern: ActionPattern<A>, worker: (action: A) => any): ForkEffect
+export function takeLeading<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -1090,12 +1091,12 @@ export function throttle<P extends ActionPattern, Fn extends (...args: any[]) =>
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
-export function throttle<A extends Action>(
+export function throttle<A extends Action<ActionType>>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect
-export function throttle<A extends Action, Fn extends (...args: any[]) => any>(
+export function throttle<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: Fn,
@@ -1181,12 +1182,12 @@ export function debounce<P extends ActionPattern, Fn extends (...args: any[]) =>
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
-export function debounce<A extends Action>(
+export function debounce<A extends Action<ActionType>>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect
-export function debounce<A extends Action, Fn extends (...args: any[]) => any>(
+export function debounce<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: Fn,

--- a/packages/core/types/effects.test.ts
+++ b/packages/core/types/effects.test.ts
@@ -28,7 +28,7 @@ import {
   debounce,
 } from 'redux-saga/effects'
 import { Action, ActionCreator } from 'redux'
-import { StringableActionCreator, ActionMatchingPattern } from '@redux-saga/types'
+import { StringableActionCreator, ActionMatchingPattern, ActionType } from '@redux-saga/types'
 
 interface MyAction extends Action {
   customField: string
@@ -53,6 +53,9 @@ declare const channel: Channel<ChannelItem>
 declare const eventChannel: EventChannel<ChannelItem>
 declare const multicastChannel: MulticastChannel<ChannelItem>
 
+interface ACTION1 {type: 'ACTION1'}
+const action1: ACTION1 = {type: 'ACTION1'}
+
 function* testTake(): SagaIterator {
   yield take()
   yield take('my-action')
@@ -61,6 +64,10 @@ function* testTake(): SagaIterator {
 
   // $ExpectError
   yield take(() => {})
+
+  yield take<{type: 'ACTION1'}>('ACTION1')
+  // $ExpectError
+  yield take<{type: 'ACTION1'}>('ACTION2')
 
   yield take(stringableActionCreator)
 
@@ -728,6 +735,12 @@ function* testTakeEvery(): SagaIterator {
   // $ExpectError
   yield takeEvery('my-action')
 
+  yield takeEvery<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeEvery<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeEvery<ACTION1>('ACTION1', (action: ACTION2) => {})
+
   yield takeEvery('my-action', (action: Action) => {})
   yield takeEvery('my-action', (action: MyAction) => {})
   yield takeEvery('my-action', function*(action: Action): SagaIterator {})
@@ -785,7 +798,7 @@ function* testTakeEvery(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeEvery(() => {}, (action: Action) => {})
+  yield takeEvery(() => {}, (action: Action<string>) => {})
 
   yield takeEvery(stringableActionCreator, action => action.customField)
 
@@ -839,7 +852,7 @@ function* testChannelTakeEvery(): SagaIterator {
   yield takeEvery(channel)
 
   // $ExpectError
-  yield takeEvery(channel, (action: Action) => {})
+  yield takeEvery(channel, (action: Action<ActionType>) => {})
   yield takeEvery(channel, (action: ChannelItem) => {})
   yield takeEvery(channel, action => {
     // $ExpectError
@@ -884,6 +897,12 @@ function* testTakeLatest(): SagaIterator {
   yield takeLatest()
   // $ExpectError
   yield takeLatest('my-action')
+
+  yield takeLatest<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLatest<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLatest<ACTION1>('ACTION1', (action: ACTION2) => {})
 
   yield takeLatest('my-action', (action: Action) => {})
   yield takeLatest('my-action', (action: MyAction) => {})
@@ -934,7 +953,7 @@ function* testTakeLatest(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeLatest(() => {}, (action: Action) => {})
+  yield takeLatest(() => {}, (action: Action<ActionType>) => {})
 
   yield takeLatest(stringableActionCreator, action => action.customField)
 
@@ -988,7 +1007,7 @@ function* testChannelTakeLatest(): SagaIterator {
   yield takeLatest(channel)
 
   // $ExpectError
-  yield takeLatest(channel, (action: Action) => {})
+  yield takeLatest(channel, (action: Action<ActionType>) => {})
   yield takeLatest(channel, (action: ChannelItem) => {})
   yield takeLatest(channel, action => {
     // $ExpectError
@@ -1033,6 +1052,12 @@ function* testTakeLeading(): SagaIterator {
   yield takeLeading()
   // $ExpectError
   yield takeLeading('my-action')
+
+  yield takeLeading<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLeading<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLeading<ACTION1>('ACTION1', (action: ACTION2) => {})
 
   yield takeLeading('my-action', (action: Action) => {})
   yield takeLeading('my-action', (action: MyAction) => {})
@@ -1083,7 +1108,7 @@ function* testTakeLeading(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeLeading(() => {}, (action: Action) => {})
+  yield takeLeading(() => {}, (action: Action<ActionType>) => {})
 
   yield takeLeading(stringableActionCreator, action => action.customField)
 
@@ -1137,7 +1162,7 @@ function* testChannelTakeLeading(): SagaIterator {
   yield takeLeading(channel)
 
   // $ExpectError
-  yield takeLeading(channel, (action: Action) => {})
+  yield takeLeading(channel, (action: Action<ActionType>) => {})
   yield takeLeading(channel, (action: ChannelItem) => {})
   yield takeLeading(channel, action => {
     // $ExpectError
@@ -1182,6 +1207,12 @@ function* testThrottle(): SagaIterator {
   yield throttle(1)
   // $ExpectError
   yield throttle(1, 'my-action')
+
+  yield throttle<ACTION1>(1, 'ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield throttle<ACTION1>(1, 'ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield throttle<ACTION1>(1, 'ACTION1', (action: ACTION2) => {})
 
   yield throttle(1, 'my-action', (action: Action) => {})
   yield throttle(1, 'my-action', (action: MyAction) => {})
@@ -1233,7 +1264,7 @@ function* testThrottle(): SagaIterator {
   )
 
   // $ExpectError
-  yield throttle(1, () => {}, (action: Action) => {})
+  yield throttle(1, () => {}, (action: Action<ActionType>) => {})
 
   yield throttle(1, stringableActionCreator, action => action.customField)
 
@@ -1290,7 +1321,7 @@ function* testChannelThrottle(): SagaIterator {
   yield throttle(1, channel)
 
   // $ExpectError
-  yield throttle(1, channel, (action: Action) => {})
+  yield throttle(1, channel, (action: Action<ActionType>) => {})
   yield throttle(1, channel, (action: ChannelItem) => {})
   yield throttle(1, channel, action => {
     // $ExpectError
@@ -1335,6 +1366,12 @@ function* testDebounce(): SagaIterator {
   yield debounce(1)
   // $ExpectError
   yield debounce(1, 'my-action')
+
+  yield debounce<ACTION1>(1, 'ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield debounce<ACTION1>(1, 'ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield debounce<ACTION1>(1, 'ACTION1', (action: ACTION2) => {})
 
   yield debounce(1, 'my-action', (action: Action) => {})
   yield debounce(1, 'my-action', (action: MyAction) => {})
@@ -1386,7 +1423,7 @@ function* testDebounce(): SagaIterator {
   )
 
   // $ExpectError
-  yield debounce(1, () => {}, (action: Action) => {})
+  yield debounce(1, () => {}, (action: Action<ActionType>) => {})
 
   yield debounce(1, stringableActionCreator, action => action.customField)
 
@@ -1443,7 +1480,7 @@ function* testChannelDebounce(): SagaIterator {
   yield debounce(1, channel)
 
   // $ExpectError
-  yield debounce(1, channel, (action: Action) => {})
+  yield debounce(1, channel, (action: Action<ActionType>) => {})
   yield debounce(1, channel, (action: ChannelItem) => {})
   yield debounce(1, channel, action => {
     // $ExpectError

--- a/packages/core/types/ts3.6/effects.d.ts
+++ b/packages/core/types/ts3.6/effects.d.ts
@@ -15,6 +15,7 @@ import {
   StrictEffect,
   ActionMatchingPattern,
   SagaIterator,
+  ActionType,
 } from '@redux-saga/types'
 
 import { FlushableChannel, PuttableChannel, TakeableChannel } from './index'
@@ -75,7 +76,7 @@ export const effectTypes: {
  * before terminating the Task.
  */
 export function take(pattern?: ActionPattern): TakeEffect
-export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
+export function take<A extends Action<ActionType>>(pattern?: ActionPattern<A>): TakeEffect
 
 /**
  * Same as `take(pattern)` but does not automatically terminate the Saga on an
@@ -96,7 +97,7 @@ export function take<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
  * is getting closed when `dispatch(END)` happens
  */
 export function takeMaybe(pattern?: ActionPattern): TakeEffect
-export function takeMaybe<A extends Action>(pattern?: ActionPattern<A>): TakeEffect
+export function takeMaybe<A extends Action<ActionType>>(pattern?: ActionPattern<A>): TakeEffect
 
 export type TakeEffect = SimpleEffect<'TAKE', TakeEffectDescriptor>
 
@@ -186,11 +187,11 @@ export function takeEvery<P extends ActionPattern, Fn extends (...args: any[]) =
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect<never>
-export function takeEvery<A extends Action>(
+export function takeEvery<A extends Action<ActionType>>(
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect<never>
-export function takeEvery<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeEvery<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -270,11 +271,11 @@ export function takeLatest<P extends ActionPattern, Fn extends (...args: any[]) 
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect<never>
-export function takeLatest<A extends Action>(
+export function takeLatest<A extends Action<ActionType>>(
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect<never>
-export function takeLatest<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeLatest<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -348,11 +349,11 @@ export function takeLeading<P extends ActionPattern, Fn extends (...args: any[])
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect<never>
-export function takeLeading<A extends Action>(
+export function takeLeading<A extends Action<ActionType>>(
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect<never>
-export function takeLeading<A extends Action, Fn extends (...args: any[]) => any>(
+export function takeLeading<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>
@@ -1127,12 +1128,12 @@ export function throttle<P extends ActionPattern, Fn extends (...args: any[]) =>
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect<never>
-export function throttle<A extends Action>(
+export function throttle<A extends Action<ActionType>>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect<never>
-export function throttle<A extends Action, Fn extends (...args: any[]) => any>(
+export function throttle<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: Fn,
@@ -1222,12 +1223,12 @@ export function debounce<P extends ActionPattern, Fn extends (...args: any[]) =>
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect<never>
-export function debounce<A extends Action>(
+export function debounce<A extends Action<ActionType>>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect<never>
-export function debounce<A extends Action, Fn extends (...args: any[]) => any>(
+export function debounce<A extends Action<ActionType>, Fn extends (...args: any[]) => any>(
   ms: number,
   pattern: ActionPattern<A>,
   worker: Fn,

--- a/packages/core/types/ts3.6/effects.test.ts
+++ b/packages/core/types/ts3.6/effects.test.ts
@@ -28,7 +28,7 @@ import {
   debounce,
 } from 'redux-saga/effects'
 import { Action, ActionCreator } from 'redux'
-import { StringableActionCreator, ActionMatchingPattern } from '@redux-saga/types'
+import { StringableActionCreator, ActionMatchingPattern, ActionType } from '@redux-saga/types'
 
 interface MyAction extends Action {
   customField: string
@@ -53,6 +53,9 @@ declare const channel: Channel<ChannelItem>
 declare const eventChannel: EventChannel<ChannelItem>
 declare const multicastChannel: MulticastChannel<ChannelItem>
 
+interface ACTION1 {type: 'ACTION1'}
+const action1: ACTION1 = {type: 'ACTION1'}
+
 function* testTake(): SagaIterator {
   yield take()
   yield take('my-action')
@@ -61,6 +64,10 @@ function* testTake(): SagaIterator {
 
   // $ExpectError
   yield take(() => {})
+
+  yield take<{type: 'ACTION1'}>('ACTION1')
+  // $ExpectError
+  yield take<{type: 'ACTION1'}>('ACTION2')
 
   yield take(stringableActionCreator)
 
@@ -728,6 +735,12 @@ function* testTakeEvery(): SagaIterator {
   // $ExpectError
   yield takeEvery('my-action')
 
+  yield takeEvery<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeEvery<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeEvery<ACTION1>('ACTION1', (action: ACTION2) => {})
+
   yield takeEvery('my-action', (action: Action) => {})
   yield takeEvery('my-action', (action: MyAction) => {})
   yield takeEvery('my-action', function*(action: Action): SagaIterator {})
@@ -785,7 +798,7 @@ function* testTakeEvery(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeEvery(() => {}, (action: Action) => {})
+  yield takeEvery(() => {}, (action: Action<ActionType>) => {})
 
   yield takeEvery(stringableActionCreator, action => action.customField)
 
@@ -839,7 +852,7 @@ function* testChannelTakeEvery(): SagaIterator {
   yield takeEvery(channel)
 
   // $ExpectError
-  yield takeEvery(channel, (action: Action) => {})
+  yield takeEvery(channel, (action: Action<ActionType>) => {})
   yield takeEvery(channel, (action: ChannelItem) => {})
   yield takeEvery(channel, action => {
     // $ExpectError
@@ -884,6 +897,12 @@ function* testTakeLatest(): SagaIterator {
   yield takeLatest()
   // $ExpectError
   yield takeLatest('my-action')
+
+  yield takeLatest<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLatest<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLatest<ACTION1>('ACTION1', (action: ACTION2) => {})
 
   yield takeLatest('my-action', (action: Action) => {})
   yield takeLatest('my-action', (action: MyAction) => {})
@@ -934,7 +953,7 @@ function* testTakeLatest(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeLatest(() => {}, (action: Action) => {})
+  yield takeLatest(() => {}, (action: Action<ActionType>) => {})
 
   yield takeLatest(stringableActionCreator, action => action.customField)
 
@@ -988,7 +1007,7 @@ function* testChannelTakeLatest(): SagaIterator {
   yield takeLatest(channel)
 
   // $ExpectError
-  yield takeLatest(channel, (action: Action) => {})
+  yield takeLatest(channel, (action: Action<ActionType>) => {})
   yield takeLatest(channel, (action: ChannelItem) => {})
   yield takeLatest(channel, action => {
     // $ExpectError
@@ -1033,6 +1052,12 @@ function* testTakeLeading(): SagaIterator {
   yield takeLeading()
   // $ExpectError
   yield takeLeading('my-action')
+
+  yield takeLeading<ACTION1>('ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLeading<ACTION1>('ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield takeLeading<ACTION1>('ACTION1', (action: ACTION2) => {})
 
   yield takeLeading('my-action', (action: Action) => {})
   yield takeLeading('my-action', (action: MyAction) => {})
@@ -1083,7 +1108,7 @@ function* testTakeLeading(): SagaIterator {
   )
 
   // $ExpectError
-  yield takeLeading(() => {}, (action: Action) => {})
+  yield takeLeading(() => {}, (action: Action<ActionType>) => {})
 
   yield takeLeading(stringableActionCreator, action => action.customField)
 
@@ -1137,7 +1162,7 @@ function* testChannelTakeLeading(): SagaIterator {
   yield takeLeading(channel)
 
   // $ExpectError
-  yield takeLeading(channel, (action: Action) => {})
+  yield takeLeading(channel, (action: Action<ActionType>) => {})
   yield takeLeading(channel, (action: ChannelItem) => {})
   yield takeLeading(channel, action => {
     // $ExpectError
@@ -1182,6 +1207,12 @@ function* testThrottle(): SagaIterator {
   yield throttle(1)
   // $ExpectError
   yield throttle(1, 'my-action')
+
+  yield throttle<ACTION1>(1, 'ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield throttle<ACTION1>(1, 'ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield throttle<ACTION1>(1, 'ACTION1', (action: ACTION2) => {})
 
   yield throttle(1, 'my-action', (action: Action) => {})
   yield throttle(1, 'my-action', (action: MyAction) => {})
@@ -1233,7 +1264,7 @@ function* testThrottle(): SagaIterator {
   )
 
   // $ExpectError
-  yield throttle(1, () => {}, (action: Action) => {})
+  yield throttle(1, () => {}, (action: Action<ActionType>) => {})
 
   yield throttle(1, stringableActionCreator, action => action.customField)
 
@@ -1290,7 +1321,7 @@ function* testChannelThrottle(): SagaIterator {
   yield throttle(1, channel)
 
   // $ExpectError
-  yield throttle(1, channel, (action: Action) => {})
+  yield throttle(1, channel, (action: Action<ActionType>) => {})
   yield throttle(1, channel, (action: ChannelItem) => {})
   yield throttle(1, channel, action => {
     // $ExpectError
@@ -1335,6 +1366,12 @@ function* testDebounce(): SagaIterator {
   yield debounce(1)
   // $ExpectError
   yield debounce(1, 'my-action')
+
+  yield debounce<ACTION1>(1, 'ACTION1', (action: ACTION1) => {})
+  // $ExpectError
+  yield debounce<ACTION1>(1, 'ACTION2', (action: ACTION1) => {})
+  // $ExpectError
+  yield debounce<ACTION1>(1, 'ACTION1', (action: ACTION2) => {})
 
   yield debounce(1, 'my-action', (action: Action) => {})
   yield debounce(1, 'my-action', (action: MyAction) => {})
@@ -1386,7 +1423,7 @@ function* testDebounce(): SagaIterator {
   )
 
   // $ExpectError
-  yield debounce(1, () => {}, (action: Action) => {})
+  yield debounce(1, () => {}, (action: Action<ActionType>) => {})
 
   yield debounce(1, stringableActionCreator, action => action.customField)
 
@@ -1443,7 +1480,7 @@ function* testChannelDebounce(): SagaIterator {
   yield debounce(1, channel)
 
   // $ExpectError
-  yield debounce(1, channel, (action: Action) => {})
+  yield debounce(1, channel, (action: Action<ActionType>) => {})
   yield debounce(1, channel, (action: ChannelItem) => {})
   yield debounce(1, channel, action => {
     // $ExpectError

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -24,21 +24,21 @@ export type SubPattern<T> = Predicate<T> | StringableActionCreator | ActionType
 
 export type Pattern<T> = SubPattern<T> | SubPattern<T>[]
 
-export type ActionSubPattern<Guard extends Action = Action> =
+export type ActionSubPattern<Guard extends Action<ActionType> = Action<ActionType>> =
   | GuardPredicate<Guard, Action>
   | StringableActionCreator<Guard>
   | Predicate<Action>
-  | ActionType
+  | Guard['type']
 
-export type ActionPattern<Guard extends Action = Action> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]
+export type ActionPattern<Guard extends Action<ActionType> = Action<ActionType>> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]
 
 export type ActionMatchingPattern<P extends ActionPattern> = P extends ActionSubPattern
   ? ActionMatchingSubPattern<P>
   : P extends ActionSubPattern[] ? ActionMatchingSubPattern<P[number]> : never
 
-export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends GuardPredicate<infer A, Action>
+export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends GuardPredicate<infer A, Action<ActionType>>
   ? A
-  : P extends StringableActionCreator<infer A> ? A : Action
+  : P extends StringableActionCreator<infer A> ? A : Action<ActionType>
 
 /**
  * Used to implement the buffering strategy for a channel. The Buffer interface

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -14,7 +14,7 @@ export type ActionType = string | number | symbol
 
 export type Predicate<T> = (arg: T) => boolean
 
-export type StringableActionCreator<A extends Action = Action> = {
+export type StringableActionCreator<A extends Action<ActionType> = Action<ActionType>> = {
   (...args: any[]): A
   toString(): string
 }
@@ -23,21 +23,21 @@ export type SubPattern<T> = Predicate<T> | StringableActionCreator | ActionType
 
 export type Pattern<T> = SubPattern<T> | SubPattern<T>[]
 
-export type ActionSubPattern<Guard extends Action = Action> =
+export type ActionSubPattern<Guard extends Action<ActionType> = Action<ActionType>> =
   | GuardPredicate<Guard, Action>
   | StringableActionCreator<Guard>
   | Predicate<Action>
-  | ActionType
+  | Guard['type']
 
-export type ActionPattern<Guard extends Action = Action> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]
+export type ActionPattern<Guard extends Action<ActionType> = Action<ActionType>> = ActionSubPattern<Guard> | ActionSubPattern<Guard>[]
 
 export type ActionMatchingPattern<P extends ActionPattern> = P extends ActionSubPattern
   ? ActionMatchingSubPattern<P>
   : P extends ActionSubPattern[] ? ActionMatchingSubPattern<P[number]> : never
 
-export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends GuardPredicate<infer A, Action>
+export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends GuardPredicate<infer A, Action<ActionType>>
   ? A
-  : P extends StringableActionCreator<infer A> ? A : Action
+  : P extends StringableActionCreator<infer A> ? A : Action<ActionType>
 
 /**
  * Used to implement the buffering strategy for a channel. The Buffer interface


### PR DESCRIPTION
… type is provided

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #1543  <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->
Adds strong typecheck for take, takeLatest, takeLeading, takeEvery, throttle and debounce effects if type explicitly provided. For example, 

```
interface ACTION1 {
    type: 'ACTION1'
}
take<ACTION1>('ACTION1'); // Only 'ACTION1' can be provided as first argument of take effect 
```