### PR TITLE
Add chat article to external resources list

### DIFF
--- a/docs/ExternalResources.md
+++ b/docs/ExternalResources.md
@@ -31,6 +31,7 @@
 - [A Redux First Router Saga](https://medium.com/@bryanfillmer/a-redux-first-router-saga-67c2cda9252e) by Bryan Fillmer
 - [What is Redux-Saga?](https://engineering.universe.com/what-is-redux-saga-c1252fc2f4d1) by Alex Richardson
 - [Lost with Redux and sagas? Implement them yourself!](https://blog.castiel.me/posts/2019-08-03-lost-redux-saga-reimplement-them/) by Sébastien Castiel
+- [Assembling Robust Web Chat Applications with JavaScript: An In-depth Guide](https://medium.com/carousell-insider/assembling-robust-web-chat-applications-with-javascript-an-in-depth-guide-9f36685fc1bc) by Yao-Hui Chua
 
 ### Videos on redux-saga
 - [Async React with Redux Saga](https://egghead.io/courses/async-react-with-redux-saga) by Tyler Clark


### PR DESCRIPTION
Hey @Andarist, I've been working with sagas on the job and I've written a Medium article which touches on [how they've been used to develop our chat UI](https://medium.com/carousell-insider/assembling-robust-web-chat-applications-with-javascript-an-in-depth-guide-9f36685fc1bc). This article:
- Provides diagrams and examples of how developers can use specific effects to handle common requirements such as [typing statuses](https://gist.github.com/superburrito/e39059e2cd63a09852242e5f3e90dfcf) and [pending messages](https://gist.github.com/superburrito/ce6d431742479eb46f358ca2c2fc25f8) 
- Highlights the role of the `eventChannel` in [connecting socket modules to the app's saga layer](https://gist.github.com/superburrito/817ae2101ec2a157f36c8e77dc70de84)

Might be a useful reference for any saga devs who work with chat apps, do you think it'll be a good addition to the current list?