### PR TITLE
fix(docs): add import statement in effects example

### DIFF
--- a/docs/basics/UsingSagaHelpers.md
+++ b/docs/basics/UsingSagaHelpers.md
@@ -12,14 +12,15 @@ First we create the task that will perform the asynchronous action:
 
 ```javascript
 import { call, put } from 'redux-saga/effects'
+import Api from './path/to/api'
 
 export function* fetchData(action) {
-   try {
-      const data = yield call(Api.fetchUser, action.payload.url)
-      yield put({type: "FETCH_SUCCEEDED", data})
-   } catch (error) {
-      yield put({type: "FETCH_FAILED", error})
-   }
+  try {
+    const data = yield call(Api.fetchUser, action.payload.url)
+    yield put({ type: 'FETCH_SUCCEEDED', data })
+  } catch (error) {
+    yield put({ type: 'FETCH_FAILED', error })
+  }
 }
 ```
 


### PR DESCRIPTION
This pull request contains a fix for an example. The examples uses `Api` but it was not imported.  