### PR TITLE
Improve Task typing.

### DIFF
--- a/.changeset/loud-hounds-kneel.md
+++ b/.changeset/loud-hounds-kneel.md
@@ -1,0 +1,7 @@
+---
+"@redux-saga/types": patch
+"@redux-saga/core": patch
+"redux-saga": patch
+---
+
+A generic type has been added to the `Task` interface and that should be preferred over using a generic parameter in `Task#result` and `Task#toPromise`.

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -143,7 +143,7 @@ export type END = { type: '@@redux-saga/CHANNEL_END' }
  * The Task interface specifies the result of running a Saga using `fork`,
  * `middleware.run` or `runSaga`.
  */
-export interface Task {
+export interface Task<T = any> {
   /**
    * Returns true if the task hasn't yet returned or thrown an error
    */
@@ -155,7 +155,7 @@ export interface Task {
   /**
    * Returns task return value. `undefined` if task is still running
    */
-  result<T = any>(): T | undefined
+  result(): T | undefined
   /**
    * Returns task thrown error. `undefined` if task is still running
    */
@@ -165,7 +165,7 @@ export interface Task {
    * - resolved with task's return value
    * - rejected with task's thrown error
    */
-  toPromise<T = any>(): Promise<T>
+  toPromise(): Promise<T>
   /**
    * Cancels the task (If it is still running)
    */

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -155,7 +155,7 @@ export interface Task<T = any> {
   /**
    * Returns task return value. `undefined` if task is still running
    */
-  result(): T | undefined
+  result<R = T>(): R | undefined
   /**
    * Returns task thrown error. `undefined` if task is still running
    */
@@ -165,7 +165,7 @@ export interface Task<T = any> {
    * - resolved with task's return value
    * - rejected with task's thrown error
    */
-  toPromise(): Promise<T>
+  toPromise<R = T>(): Promise<R>
   /**
    * Cancels the task (If it is still running)
    */

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -151,7 +151,7 @@ export type END = { type: '@@redux-saga/CHANNEL_END' }
  * The Task interface specifies the result of running a Saga using `fork`,
  * `middleware.run` or `runSaga`.
  */
-export interface Task {
+export interface Task<T = any> {
   /**
    * Returns true if the task hasn't yet returned or thrown an error
    */
@@ -163,7 +163,7 @@ export interface Task {
   /**
    * Returns task return value. `undefined` if task is still running
    */
-  result<T = any>(): T | undefined
+  result(): T | undefined
   /**
    * Returns task thrown error. `undefined` if task is still running
    */
@@ -173,7 +173,7 @@ export interface Task {
    * - resolved with task's return value
    * - rejected with task's thrown error
    */
-  toPromise<T = any>(): Promise<T>
+  toPromise(): Promise<T>
   /**
    * Cancels the task (If it is still running)
    */

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -163,7 +163,7 @@ export interface Task<T = any> {
   /**
    * Returns task return value. `undefined` if task is still running
    */
-  result(): T | undefined
+  result<R = T>(): R | undefined
   /**
    * Returns task thrown error. `undefined` if task is still running
    */
@@ -173,7 +173,7 @@ export interface Task<T = any> {
    * - resolved with task's return value
    * - rejected with task's thrown error
    */
-  toPromise(): Promise<T>
+  toPromise<R = T>(): Promise<R>
   /**
    * Cancels the task (If it is still running)
    */


### PR DESCRIPTION
Hi,

I just moved the generic type of `Task` interface up because I think it's more correct and it'll actually prevent [this hack](https://github.com/agiledigital/typed-redux-saga/pull/10/files#diff-88bec6beae84369c0376b56b3bb88fe1R261) in typed-redux-saga. Depending on your definition of breaking change, [it might be one](https://xkcd.com/1172/), but I think it's acceptable because it only affect types, it's very easy to fix and I don't think that many people have provided an explicit generic type for `result` and `toPromise` anyways (apart from typed-redux-saga of course).

If you're too concerned by this, I can put the generic back on `toPromise` and `result` and make it equal `T` by default (which would be cumbersome IMHO, but would be completely safe regarding BCs).

Thanks for your time :clap: .