### PR TITLE
update(packages/core/package.json): funding.url uses redux-saga

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://redux-saga.js.org/",
   "funding": {
     "type": "opencollective",
-    "url": "https://opencollective.com/xstate"
+    "url": "https://opencollective.com/redux-saga"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.3",


### PR DESCRIPTION
xstate was listed as the opencollective url. I believe this should be
https://opencollective.com/redux-saga instead.

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | N/A |
| Patch: Bug Fix?          | No  |
| Major: Breaking Change?  | No  |
| Minor: New Feature?      | No |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |  No   |

<!-- Describe your changes below in as much detail as possible -->
