### PR TITLE
Document: Fix wrong dispatch document url

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -355,7 +355,7 @@ You can, however, expect the store to be updated in the current stack frame (i.e
 
 Downstream errors (e.g. from the reducer) will be bubbled up.
 
-- `action: Object` - [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+- `action: Object` - [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
 
 ### `putResolve(action)`
 

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -362,7 +362,7 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
  * action to the Store. This effect is non-blocking and any errors that are
  * thrown downstream (e.g. in a reducer) will not bubble back into the saga.
  *
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<A extends Action>(action: A): PutEffect<A>
 
@@ -371,7 +371,7 @@ export function put<A extends Action>(action: A): PutEffect<A>
  * `dispatch` it will wait for its resolution) and will bubble up errors from
  * downstream.
  *
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function putResolve<A extends Action>(action: A): PutEffect<A>
 
@@ -392,7 +392,7 @@ export interface PutEffectDescriptor<A extends Action> {
  * into the saga.
  *
  * @param channel a `Channel` Object.
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<T>(channel: PuttableChannel<T>, action: T | END): ChannelPutEffect<T>
 

--- a/packages/core/types/ts3.6/effects.d.ts
+++ b/packages/core/types/ts3.6/effects.d.ts
@@ -381,7 +381,7 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
  * action to the Store. This effect is non-blocking and any errors that are
  * thrown downstream (e.g. in a reducer) will not bubble back into the saga.
  *
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<A extends Action>(action: A): PutEffect<A>
 
@@ -390,7 +390,7 @@ export function put<A extends Action>(action: A): PutEffect<A>
  * `dispatch` it will wait for its resolution) and will bubble up errors from
  * downstream.
  *
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function putResolve<A extends Action>(action: A): PutEffect<A>
 
@@ -411,7 +411,7 @@ export interface PutEffectDescriptor<A extends Action> {
  * into the saga.
  *
  * @param channel a `Channel` Object.
- * @param action [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+ * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<T>(channel: PuttableChannel<T>, action: T | END): ChannelPutEffect<T>
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | No issue Ticket |
| Patch: Bug Fix?          | No   |
| Major: Breaking Change?  | No    |
| Minor: New Feature?      | No    |
| Tests Added + Pass?      | Not needed |
| Any Dependency Changes?  | No   |

<!-- Describe your changes below in as much detail as possible -->
[redux saga doc - dispatch link](https://redux.js.org/docs/api/Store.html#dispatch)is broken.
