### PR TITLE
Removed --save option from npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You might've used `redux-thunk` before to handle your data fetching. Contrary to
 ## Install
 
 ```sh
-$ npm install --save redux-saga
+$ npm install redux-saga
 ```
 or
 


### PR DESCRIPTION
As of npm 5 and in latest npm/cli `save` is a default option. One may use --no-save to skip saving to package.json.

It is just a pull request for readme.md file.