### PR TITLE
[docs] Fixes #2055 broken links in section 'Troubleshooting'

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -96,13 +96,13 @@ As a result, you can see something like this in your console.
 ![saga-error-stack.png](./assets/saga-error-stack.png)
 
 If you want to have those "saga stack" with file names and line numbers for **development purposes**, you can add [babel-plugin](https://www.npmjs.com/package/babel-plugin-redux-saga), which allows you to have enhanced information.
-Docs are available [here](../packages/babel-plugin-redux-saga).
-For babel-plugin usage example check [this example](../examples/error-demo)
+Docs are available [here]([../packages/babel-plugin-redux-saga](https://github.com/redux-saga/redux-saga/tree/master/packages/babel-plugin-redux-saga)).
+For babel-plugin usage example check [this example](https://github.com/redux-saga/redux-saga/tree/master/packages/babel-plugin-redux-saga#example)
 
 After adding `babel-plugin-redux-saga` the same output looks like
 
 ![saga-error-stack-with-babel-plugin.png](./assets/saga-error-stack-with-babel-plugin.png)
 
-Note: [It works for testing as well](../examples/error-demo/test/sagas.js), just make sure you (or your runner) run saga via `sagaMiddleware`.
+Note: [It works for testing as well](https://github.com/redux-saga/redux-saga/tree/master/examples/error-demo), just make sure you (or your runner) run saga via `sagaMiddleware`.
 
 ![saga-error-stack-node.png](./assets/saga-error-stack-node.png)


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #2055 |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

Fixes a few broken links in the documentation site under the section, "Troubleshooting".
