### PR TITLE
Add pointer to the jasmine test framework.

### DIFF
--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -77,7 +77,7 @@ There is another direction where the cancellation propagates to as well: the joi
 
 ## Testing generators with fork effect
 
-When `fork` is called it starts the task in the background and also returns task object like we have learned previously. When testing this we have to use utility function `createMockTask`. Object returned from this function should be passed to next `next` call after fork test. Mock task can then be passed to `cancel` for example. Here is test for `main` generator which is on top of this page.
+When `fork` is called it starts the task in the background and also returns task object like we have learned previously. When testing this we have to use utility function `createMockTask`. Object returned from this function should be passed to next `next` call after fork test. Mock task can then be passed to `cancel` for example. Here is test for `main` generator which is on top of this page (the example uses the [jasmine](https://jasmine.github.io/2.2/introduction.html) test framework).
 
 ```javascript
 import { createMockTask } from '@redux-saga/testing-utils';

--- a/docs/advanced/Testing.md
+++ b/docs/advanced/Testing.md
@@ -406,7 +406,7 @@ test('with redux-saga-tester', () => {
 ## `effectMiddlwares`
 Provides a native way to perform integration like testing without one of the above libraries.
 
-The idea is that you can create a real redux store with saga middleware in your test file. The saga middlware takes an object as an argument. That object would have an `effectMiddlewares` value: a function where you can intercept/hijack any effect and resolve it on your own - passing it very redux-style to the next middleware.
+The idea is that you can create a real redux store with saga middleware in your test file. The saga middleware takes an object as an argument. That object would have an `effectMiddlewares` value: a function where you can intercept/hijack any effect and resolve it on your own - passing it very redux-style to the next middleware.
 
 In your test, you would start a saga, intercept/resolve async effects with effectMiddlewares and assert on things like state updates to test integration between your saga and a store.
 


### PR DESCRIPTION
The example uses it() from jasmine, but there is no mention of that in the documentation, so new users unfamiliar with jasmine will be confused.

I found 
https://stackoverflow.com/questions/28353232/what-is-the-it-function-here-doing
which pointed me in the right direction.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | No issue mentions this, but i can open one if so desired |
| Patch: Bug Fix?          |  Documentation improvement   |
| Major: Breaking Change?  |   No |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |   No |

<!-- Describe your changes below in as much detail as possible -->

I added a pointer to the jasmine test framework in https://redux-saga.js.org/docs/advanced/TaskCancellation.html 