### PR TITLE
Add warnings for invalid use of `take` effect

### DIFF
--- a/.changeset/wise-owls-hug.md
+++ b/.changeset/wise-owls-hug.md
@@ -1,0 +1,6 @@
+---
+'@redux-saga/core': patch
+'redux-saga': patch
+---
+
+Added warnings when using take(channelOrPattern) with more than one parameter

--- a/.changeset/wise-owls-hug.md
+++ b/.changeset/wise-owls-hug.md
@@ -3,4 +3,4 @@
 'redux-saga': patch
 ---
 
-Added warnings when using take(channelOrPattern) with more than one parameter
+Added warnings when using `take(channelOrPattern)` incorrectly with more than one parameter. It helps to surface problem with `take(ACTION_A, ACTION_B)` being used instead of `take([ACTION_A, ACTION_B])`.

--- a/packages/core/src/internal/io.js
+++ b/packages/core/src/internal/io.js
@@ -30,12 +30,18 @@ export function take(patternOrChannel = '*', multicastPattern) {
     check(arguments[0], is.notUndef, 'take(patternOrChannel): patternOrChannel is undefined')
   }
   if (is.pattern(patternOrChannel)) {
+    if (is.notUndef(multicastPattern)) {
+      console.warn(`take(pattern) takes one argument but two were provided. Consider passing an array for listening to several action types`)
+    }
     return makeEffect(effectTypes.TAKE, { pattern: patternOrChannel })
   }
   if (is.multicast(patternOrChannel) && is.notUndef(multicastPattern) && is.pattern(multicastPattern)) {
     return makeEffect(effectTypes.TAKE, { channel: patternOrChannel, pattern: multicastPattern })
   }
   if (is.channel(patternOrChannel)) {
+    if (is.notUndef(multicastPattern)) {
+      console.warn(`take(channel) takes one argument but two were provided. Second argument is ignored.`)
+    }
     return makeEffect(effectTypes.TAKE, { channel: patternOrChannel })
   }
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | No <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?          |  No  |
| Major: Breaking Change?  | No   |
| Minor: New Feature?      |   No |
| Tests Added + Pass?      | No |
| Any Dependency Changes?  | No   |

<!-- Describe your changes below in as much detail as possible -->
Several times I've been surprised and disheartened by ``` take(`type1`, `type2`) ``` silently accepting the task and working as expected for the first argument `type1` but not for the second `type2`. I'm sure I'm not the only one who has encountered this little trap.

The issue is that multiple types must be placed in an array. That effect takes a single argument when used with pattern or channel.

This tiny PR just adds some friendly warnings. I can change the wording or tone if needed.