### PR TITLE
Type to infer the return type of an EventChannel

### DIFF
--- a/.changeset/breezy-peas-report.md
+++ b/.changeset/breezy-peas-report.md
@@ -1,0 +1,9 @@
+---
+"@redux-saga/core": patch
+---
+
+Add a type `EventChannelReturnType` that can be used to infer the return type of an EventChannel:
+
+```
+const result: EventChannelReturnType<typeof AnEventChannel> = yield take(AnEventChannel);
+```

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -317,6 +317,8 @@ export interface EventChannel<T> {
   close(): void
 }
 
+export type EventChannelReturnType<T> = T extends EventChannel<infer U> ? U : never;
+
 export interface PredicateTakeableChannel<T> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
 }

--- a/packages/core/types/ts3.6/index.d.ts
+++ b/packages/core/types/ts3.6/index.d.ts
@@ -316,6 +316,8 @@ export interface EventChannel<T> {
   close(): void
 }
 
+export type EventChannelReturnType<T> = T extends EventChannel<infer U> ? U : never;
+
 export interface PredicateTakeableChannel<T> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
 }


### PR DESCRIPTION
Hi 👋,

I would like to add a type to infer the return type of an EventChannel:

`const result: EventChannelReturnType<typeof AnEventChannel> = yield take(AnEventChannel);`