### PR TITLE
Inline Redux `Action` type to avoid dependency on Redux

### DIFF
--- a/.changeset/silly-dogs-compete.md
+++ b/.changeset/silly-dogs-compete.md
@@ -2,4 +2,4 @@
 "@redux-saga/types": patch
 ---
 
-Add redux as dependency of @redux-saga/types
+Inline Action type to avoid dependency on Redux

--- a/.changeset/silly-dogs-compete.md
+++ b/.changeset/silly-dogs-compete.md
@@ -2,4 +2,4 @@
 "@redux-saga/types": patch
 ---
 
-Inline Action type to avoid dependency on Redux
+Inline Redux `Action` type to avoid dependency on Redux

--- a/.changeset/silly-dogs-compete.md
+++ b/.changeset/silly-dogs-compete.md
@@ -1,0 +1,5 @@
+---
+"@redux-saga/types": patch
+---
+
+Add redux as dependency of @redux-saga/types

--- a/.changeset/silly-dogs-compete.md
+++ b/.changeset/silly-dogs-compete.md
@@ -2,4 +2,4 @@
 "@redux-saga/types": patch
 ---
 
-Inline Redux `Action` type to avoid dependency on Redux
+Inlined Redux `Action` type to fix compatibility with strict package managers.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,5 +31,8 @@
   "bugs": {
     "url": "https://github.com/redux-saga/redux-saga/issues"
   },
-  "homepage": "https://redux-saga.js.org/"
+  "homepage": "https://redux-saga.js.org/",
+  "dependencies": {
+    "redux": "^4.0.4"
+  }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,8 +31,5 @@
   "bugs": {
     "url": "https://github.com/redux-saga/redux-saga/issues"
   },
-  "homepage": "https://redux-saga.js.org/",
-  "dependencies": {
-    "redux": "^4.0.4"
-  }
+  "homepage": "https://redux-saga.js.org/"
 }

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -1,5 +1,5 @@
 // TypeScript Version: 3.2
-export interface Action<T = any> {
+export interface Action<T extends string = string> {
   type: T
 }
 

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -1,5 +1,7 @@
 // TypeScript Version: 3.2
-import { Action } from 'redux'
+export interface Action<T = any> {
+  type: T
+}
 
 export type Saga<Args extends any[] = any[]> = (...args: Args) => IterableIterator<any>
 

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -1,4 +1,4 @@
-export interface Action<T = any> {
+export interface Action<T extends string = string> {
   type: T
 }
 

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -1,4 +1,6 @@
-import { Action } from 'redux'
+export interface Action<T = any> {
+  type: T
+}
 
 export type Saga<Args extends any[] = any[]> = (...args: Args) => Iterator<any>
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | N/A |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |  No  |
| Minor: New Feature?      |  No  |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |  Yes  |

Adds `redux` to the dependencies of `@redux-saga/types` to fix this type error:
```
ERROR in ../../.yarn/cache/@redux-saga-types-npm-1.1.0-2c2f416e43-e75a6ddc89.zip/node_modules/@redux-saga/types/types/ts3.6/index.d.ts 1:24-31
TS2307: Cannot find module 'redux' or its corresponding type declarations.
  > 1 | import { Action } from 'redux'
      |                        ^^^^^^^
    2 |
    3 | export type Saga<Args extends any[] = any[]> = (...args: Args) => Iterator<any>
    4 |
```