### PR TITLE
ensure tests do not run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "lint": "eslint packages/*/{src,test}",
-    "test": "lerna run test",
+    "test": "lerna --concurrency 1 run test",
     "clean": "lerna run --parallel clean && lerna clean --yes && rimraf node_modules",
     "build": "lerna run --parallel build",
     "counter": "yarn start --prefix examples/counter",


### PR DESCRIPTION

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  |
| Patch: Bug Fix?          | Fix dtslint in CI intermittently failing    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | No |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

The goal of this PR is to fix the intermittent issue with CI failing because dtslint tries to install multiple versions of typescript at the same time, causing false positive errors.

You can see the recommendation here when using lerna: https://github.com/microsoft/dtslint#faq