### PR TITLE
docs(#2276): testing examples recovered to new syntax

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1244,67 +1244,27 @@ test('my oddOrEven saga', assert => {
   const data = {};
   data.gen = cloneableGenerator(oddOrEven)();
 
-  assert.equal(
-    data.gen.next().value,
-    1,
-    'it should yield 1'
-  );
+  expect(data.gen.next().value).toBe(1)
+  expect(data.gen.next().value).toBe(2)
+  expect(data.gen.next().value).toBe(3)
 
-  assert.equal(
-    data.gen.next().value,
-    2,
-    'it should yield 2'
-  );
+  // it should ask for a number
+  expect(data.gen.next().value).toBe('enter a number')
 
-  assert.equal(
-    data.gen.next().value,
-    3,
-    'it should yield 3'
-  );
+  // we make a clone of the generator before giving the number;
+  data.clone = data.gen.clone();
+  
+  // it should yield "even"
+  expect(data.gen.next(2).value).toBe('even')
 
-  assert.equal(
-    data.gen.next().value,
-    'enter a number',
-    'it should ask for a number'
-  );
+  // it should be done
+  expect(data.gen.next().done).toBeTruthy()
 
-  assert.test('even number is given', a => {
-    // we make a clone of the generator before giving the number;
-    data.clone = data.gen.clone();
+  // it should yield "odd"
+  expect(data.clone.next(1).value).toBe('odd')
 
-    a.equal(
-      data.gen.next(2).value,
-      'even',
-      'it should yield "even"'
-    );
-
-    a.equal(
-      data.gen.next().done,
-      true,
-      'it should be done'
-    );
-
-    a.end();
-  });
-
-  assert.test('odd number is given', a => {
-
-    a.equal(
-      data.clone.next(1).value,
-      'odd',
-      'it should yield "odd"'
-    );
-
-    a.equal(
-      data.clone.next().done,
-      true,
-      'it should be done'
-    );
-
-    a.end();
-  });
-
-  assert.end();
+  // it should be done
+  expect(data.clone.next().done).toBeTruthy()
 });
 
 ```

--- a/docs/advanced/Testing.md
+++ b/docs/advanced/Testing.md
@@ -47,32 +47,24 @@ call its `next().value`:
 ```javascript
   const gen = changeColorSaga();
 
-  assert.deepEqual(
-    gen.next().value,
-    take(CHOOSE_COLOR),
-    'it should wait for a user to choose a color'
-  );
+  // it should wait for a user to choose a color
+  expect(gen.next().value).toEqual(take(CHOOSE_COLOR))
 ```
 
 A value must then be returned to assign to the `action` constant, which is used for the argument to the `put` effect:
 
 ```javascript
   const color = 'red';
-  assert.deepEqual(
-    gen.next(chooseColor(color)).value,
-    put(changeUI(color)),
-    'it should dispatch an action to change the ui'
-  );
+
+  // it should dispatch an action to change the ui
+  expect(gen.next(chooseColor(color)).value).toEqual(put(changeUI(color)))
 ```
 
 Since there are no more `yield`s, then next time `next()` is called, the generator will be done:
 
 ```javascript
-  assert.deepEqual(
-    gen.next().done,
-    true,
-    'it should be done'
-  );
+  // it should be done
+  expect(gen.next().done).toBeTruhty()
 ```
 
 ### Branching Saga
@@ -119,45 +111,33 @@ The test is as follows:
 import { put, take } from 'redux-saga/effects';
 import { cloneableGenerator } from '@redux-saga/testing-utils';
 
-test('doStuffThenChangeColor', assert => {
+describe('doStuffThenChangeColor', assert => {
   const gen = cloneableGenerator(doStuffThenChangeColor)();
   gen.next(); // DO_STUFF
   gen.next(); // DO_STUFF
   gen.next(); // CHOOSE_NUMBER
 
-  assert.test('user choose an even number', a => {
+  test('user choose an even number', () => {
     // cloning the generator before sending data
     const clone = gen.clone();
-    a.deepEqual(
-      clone.next(chooseNumber(2)).value,
-      put(changeUI('red')),
-      'should change the color to red'
-    );
 
-    a.equal(
-      clone.next().done,
-      true,
-      'it should be done'
-    );
+    // should change the color to red
+    expect(clone.next(chooseNumber(2)).value)
+      .toEqual(put(changeUI('red')))
 
-    a.end();
+    // it should be done
+    expect(clone.next().done).toBeTruthy()
   });
 
-  assert.test('user choose an odd number', a => {
+  test('user choose an odd number', () => {
     const clone = gen.clone();
-    a.deepEqual(
-      clone.next(chooseNumber(3)).value,
-      put(changeUI('blue')),
-      'should change the color to blue'
-    );
 
-    a.equal(
-      clone.next().done,
-      true,
-      'it should be done'
-    );
+    // should change the color to blue
+    expect(clone.next(chooseNumber(3)).value)
+      .toEqual(put(changeUI('blue')))
 
-    a.end();
+    // it should be done
+    expect(clone.next().done).toBeTruthy()
   });
 });
 ```
@@ -215,8 +195,10 @@ test('callApi', async (assert) => {
     getState: () => ({ state: 'test' }),
   }, callApi, url).toPromise();
 
-  assert.true(myApi.calledWith(url, somethingFromState({ state: 'test' })));
-  assert.deepEqual(dispatched, [success({ some: 'value' })]);
+  expect(myApi.calledWith(url, somethingFromState({ state: 'test' })))
+    .toBeTruthy()
+
+  expect(dispatched).toEqual([success({ some: 'value' })])
 });
 ```
 
@@ -270,7 +252,7 @@ test('with redux-saga-testing', () => {
 
   it('should select from state', apiResponse => {
     // without tape's `test`
-    assert.deepEqual(apiResponse.json(), jsonResponse);
+    expect(apiResponse.json()).toEqual(jsonResponse)
   });
 
   // an empty call to `it` can be used to skip an effect
@@ -373,11 +355,11 @@ test('testing with redux-saga-test-engine', () => {
   );
 
   // assert that the effects you care about occurred as expected, in order
-  assert.equal(actualEffects[0], call(myApi, 'url', selectedValue));
-  assert.equal(actualEffects[1], put(success, response));
+  expect(actualEffects[0]).toBe(call(myApi, 'url', selectedValue))
+  expect(actualEffects[1]).toBe(put(success, response));
 
   // assert that your saga does nothing unexpected
-  assert.true(actualEffects.length === 2);
+  expect(actualEffects.length === 2).toBeTruthy()
 });
 ```
 
@@ -402,9 +384,10 @@ test('with redux-saga-tester', () => {
 
   await sagaTester.waitFor(success);
 
-  assert.true(sagaTester.wasCalled(success(response)));
+  expect(sagaTester.wasCalled(success(response)))
+    .toBeTruthy()
 
-  assert.deepEqual(sagaTester.getState(), { data: response });
+  expect(sagaTester.getState()).toEqual({ data: response })
 });
 ```
 
@@ -419,8 +402,6 @@ Here's an example from the [docs](https://github.com/redux-saga/redux-saga/blob/
 
 ```javascript
 test('effectMiddleware', assert => {
-  assert.plan(1);
-
   let actual = [];
 
   function rootReducer(state = {}, action) {
@@ -462,13 +443,10 @@ test('effectMiddleware', assert => {
   task
     .toPromise()
     .then(() => {
-      assert.deepEqual(
-        actual,
-        expected,
-        'effectMiddleware must be able to intercept and resolve effect in a custom way',
-      )
+      // effectMiddleware must be able to intercept and resolve effect in a custom way
+      expect(actual).toEqual(expected)
     })
-    .catch(err => assert.fail(err));
+    .catch(err => expect(err).toBe(err));
 });
 ```
 

--- a/docs/basics/DeclarativeEffects.md
+++ b/docs/basics/DeclarativeEffects.md
@@ -37,7 +37,7 @@ Suppose we want to test the generator above:
 
 ```javascript
 const iterator = fetchProducts()
-assert.deepEqual(iterator.next().value, ??) // what do we expect ?
+expect(iterator.next().value).to... // what do we expect ?
 ```
 
 We want to check the result of the first value yielded by the generator. In our case it's the result of running `Api.fetch('/products')` which is a Promise . Executing the real service during tests is neither a viable nor practical approach, so we have to *mock* the `Api.fetch` function, i.e. we'll have to replace the real function with a fake one which doesn't actually run the AJAX request but only checks that we've called `Api.fetch` with the right arguments (`'/products'` in our case).
@@ -91,11 +91,7 @@ import Api from '...'
 const iterator = fetchProducts()
 
 // expects a call instruction
-assert.deepEqual(
-  iterator.next().value,
-  call(Api.fetch, '/products'),
-  "fetchProducts should yield an Effect call(Api.fetch, './products')"
-)
+expect(iterator.next().value).toEqual(call(Api.fetch, '/products'))
 ```
 
 Now we don't need to mock anything, and a basic equality test will suffice.
@@ -130,7 +126,7 @@ And of course you can test it just like you test `call`:
 import { cps } from 'redux-saga/effects'
 
 const iterator = fetchSaga()
-assert.deepEqual(iterator.next().value, cps(readFile, '/path/to/file') )
+expect(iterator.next().value).toEqual(readFile)
 ```
 
 `cps` also supports the same method invocation form as `call`.

--- a/docs/basics/DispatchingActions.md
+++ b/docs/basics/DispatchingActions.md
@@ -52,21 +52,13 @@ import Api from '...'
 const iterator = fetchProducts()
 
 // expects a call instruction
-assert.deepEqual(
-  iterator.next().value,
-  call(Api.fetch, '/products'),
-  "fetchProducts should yield an Effect call(Api.fetch, './products')"
-)
+expect(iterator.next().value).toEqual(call(Api.fetch, '/products'))
 
 // create a fake response
 const products = {}
 
 // expects a dispatch instruction
-assert.deepEqual(
-  iterator.next(products).value,
-  put({ type: 'PRODUCTS_RECEIVED', products }),
-  "fetchProducts should yield an Effect put({ type: 'PRODUCTS_RECEIVED', products })"
-)
+expect(iterator.next(products).value).toEqual(put({ type: 'PRODUCTS_RECEIVED', products }))
 ```
 
 Note how we pass the fake response to the Generator via its `next` method. Outside the

--- a/docs/basics/ErrorHandling.md
+++ b/docs/basics/ErrorHandling.md
@@ -37,21 +37,18 @@ import Api from '...'
 const iterator = fetchProducts()
 
 // expects a call instruction
-assert.deepEqual(
-  iterator.next().value,
-  call(Api.fetch, '/products'),
-  "fetchProducts should yield an Effect call(Api.fetch, './products')"
-)
+test("fetchProducts should yield an Effect call(Api.fetch, './products')", () => {
+  expect(iterator.next().value).toEqual(call(Api.fetch, '/products'))
+})
 
 // create a fake error
 const error = {}
 
 // expects a dispatch instruction
-assert.deepEqual(
-  iterator.throw(error).value,
-  put({ type: 'PRODUCTS_REQUEST_FAILED', error }),
-  "fetchProducts should yield an Effect put({ type: 'PRODUCTS_REQUEST_FAILED', error })"
-)
+test("fetchProducts should yield an Effect put({ type: 'PRODUCTS_REQUEST_FAILED', error })", () => {
+  expect(iterator.throw(error).value)
+    .toEqual(put({ type: 'PRODUCTS_REQUEST_FAILED', error }))
+})
 ```
 
 In this case, we're passing the `throw` method a fake error. This will cause the Generator to break the current flow and execute the catch block.

--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -273,11 +273,8 @@ import { incrementAsync } from './sagas'
 test('incrementAsync Saga test', (assert) => {
   const gen = incrementAsync()
 
-  assert.deepEqual(
-    gen.next(),
-    { done: false, value: ??? },
-    'incrementAsync should return a Promise that will resolve after 1 second'
-  )
+  // incrementAsync should return a Promise that will resolve after 1 second
+  expect(gen.next()).toEqual({ done: false, value: ??? })
 })
 ```
 
@@ -326,25 +323,14 @@ import { incrementAsync, delay } from './sagas'
 test('incrementAsync Saga test', (assert) => {
   const gen = incrementAsync()
 
-  assert.deepEqual(
-    gen.next().value,
-    call(delay, 1000),
-    'incrementAsync Saga must call delay(1000)'
-  )
+  // incrementAsync Saga must call delay(1000)
+  expect(gen.next().value).toEqual(call(delay, 1000))
+  
+  // incrementAsync Saga must dispatch an INCREMENT action
+  expect(gen.next().value).toEqual(put({type: 'INCREMENT'}))
 
-  assert.deepEqual(
-    gen.next().value,
-    put({type: 'INCREMENT'}),
-    'incrementAsync Saga must dispatch an INCREMENT action'
-  )
-
-  assert.deepEqual(
-    gen.next(),
-    { done: true, value: undefined },
-    'incrementAsync Saga must be done'
-  )
-
-  assert.end()
+  // incrementAsync Saga must be done
+  expect(gen.next()).toEqual({ done: true, value: undefined })
 })
 ```
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | #2276  |
| Docs updated?          |  Yes  |
| Any Dependency Changes?  |  No  |

Regarding to answer from discussion from this PR https://github.com/redux-saga/redux-saga/pull/2277, I updated code examples everywhere
