### PR TITLE
warn developer that delay has a maximum value if they exceed it and r…

### DIFF
--- a/.changeset/smart-schools-know.md
+++ b/.changeset/smart-schools-know.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/delay-p': patch
+---
+
+Fixed an issue with arguments that exceed the maximum value for the internally-used `setTimeout`. Previously it could overflow based on the input that was too big and thus a timeout could resolve immediately.

--- a/packages/core/__tests__/sagaHelpers/delay.js
+++ b/packages/core/__tests__/sagaHelpers/delay.js
@@ -1,6 +1,6 @@
 import sagaMiddleware from '../../src'
 import { createStore, applyMiddleware } from 'redux'
-import { delay } from '../../src/effects'
+import { delay, call } from '../../src/effects'
 import delayP from '@redux-saga/delay-p'
 
 test('delay', async () => {
@@ -19,4 +19,27 @@ test('delay', async () => {
   await delayP(100)
 
   expect(actual).toEqual(expected)
+})
+
+test('delay when the timeout value exceeds the maximum allowed value', () => {
+  let actual
+  const middleware = sagaMiddleware({
+    onError: err => {
+      actual = err
+    },
+  })
+  createStore(() => ({}), {}, applyMiddleware(middleware))
+
+  function* child() {
+    yield delay(2147483648)
+  }
+
+  function* main() {
+    yield call(child)
+  }
+
+  const task = middleware.run(main)
+  return task.toPromise().catch(() => {
+    expect(actual).toEqual(new Error('delay only supports a maximum value of 2147483647ms'))
+  })
 })

--- a/packages/delay-p/src/index.js
+++ b/packages/delay-p/src/index.js
@@ -1,9 +1,15 @@
 import { CANCEL } from '@redux-saga/symbols'
 
+const MAX_SIGNED_INT = 2147483647
+
 export default function delayP(ms, val = true) {
+  // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+  if (process.env.NODE_ENV !== 'production' && ms > MAX_SIGNED_INT) {
+    throw new Error('delay only supports a maximum value of ' + MAX_SIGNED_INT + 'ms')
+  }
   let timeoutId
   const promise = new Promise(resolve => {
-    timeoutId = setTimeout(resolve, ms, val)
+    timeoutId = setTimeout(resolve, Math.min(MAX_SIGNED_INT, ms), val)
   })
 
   promise[CANCEL] = () => {


### PR DESCRIPTION
…estrict delay to a value less than the max

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | #2289  |
| Patch: Bug Fix?          |  Yes  |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

This PR throws an error when the build is not in production and the developer tries to add a delay that's longer than the maximum allowed setTimeout.  [See here](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value) for more details.
