### PR TITLE
Updates types to eliminate void-emitting channel pitfall

### DIFF
--- a/.changeset/fresh-rats-switch.md
+++ b/.changeset/fresh-rats-switch.md
@@ -1,0 +1,7 @@
+---
+'@redux-saga/core': minor
+'@redux-saga/types': minor
+'redux-saga': minor
+---
+
+Updates Channel type to eliminate void-emitting pitfall

--- a/packages/core/types/channels.test.ts
+++ b/packages/core/types/channels.test.ts
@@ -59,6 +59,23 @@ function testChannel() {
   c1.flush((messages: Array<{foo: string}> | END) => {});
 
   c1.close();
+
+  // Testing that we can't define channels that pass void or undefined
+  // $ExpectError
+  const voidChannel: Channel<void> = channel();
+  // $ExpectError
+  const voidChannel2 = channel<void>();
+  // $ExpectError
+  const undefinedChannel = channel<undefined>();
+  // $ExpectError
+  channel().put();
+  // $ExpectError
+  channel().put(undefined);
+
+  // Testing that we can pass primitives into channels
+  channel().put(42);
+  channel().put('test');
+  channel().put(true);
 }
 
 function testEventChannel(secs: number) {
@@ -100,6 +117,21 @@ function testEventChannel(secs: number) {
   c1.flush((messages: number[] | END) => {});
 
   c1.close();
+
+  // $ExpectError
+  const c4: EventChannel<void> = eventChannel(() => () => {})
+
+  // $ExpectError
+  const c5 = eventChannel<void>(emit => {
+    emit()
+    return () => {}
+  })
+
+  const c6 = eventChannel(emit => {
+    // $ExpectError
+    emit()
+    return () => {}
+  })
 }
 
 function testMulticastChannel() {
@@ -121,4 +153,11 @@ function testMulticastChannel() {
   c1.flush((messages: Array<{foo: string}> | END) => {});
 
   c1.close();
+
+  // $ExpectError
+  const c3: MulticastChannel<void> = stdChannel()
+  // $ExpectError
+  const c4 = multicastChannel<void>()
+  // $ExpectError
+  const c5 = stdChannel<void>()
 }

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 3.2
 import { Action, Middleware } from 'redux'
-import { Saga, Buffer, Channel, END as EndType, Predicate, SagaIterator, Task } from '@redux-saga/types'
+import { Saga, Buffer, Channel, END as EndType, Predicate, SagaIterator, Task, NotUndefined } from '@redux-saga/types'
 import { ForkEffect } from './effects'
 
 export { Saga, SagaIterator, Buffer, Channel, Task }
@@ -265,7 +265,7 @@ export interface FlushableChannel<T> {
  * buffering will deliver message using a FIFO strategy: a new taker will be
  * delivered the oldest message in the buffer.
  */
-export function channel<T>(buffer?: Buffer<T>): Channel<T>
+export function channel<T extends NotUndefined>(buffer?: Buffer<T>): Channel<T>
 
 /**
  * Creates channel that will subscribe to an event source using the `subscribe`
@@ -306,12 +306,12 @@ export function channel<T>(buffer?: Buffer<T>): Channel<T>
  * @param buffer optional Buffer object to buffer messages on this channel. If
  *   not provided, messages will not be buffered on this channel.
  */
-export function eventChannel<T>(subscribe: Subscribe<T>, buffer?: Buffer<T>): EventChannel<T>
+export function eventChannel<T extends NotUndefined>(subscribe: Subscribe<T>, buffer?: Buffer<T>): EventChannel<T>
 
 export type Subscribe<T> = (cb: (input: T | END) => void) => Unsubscribe
 export type Unsubscribe = () => void
 
-export interface EventChannel<T> {
+export interface EventChannel<T extends NotUndefined> {
   take(cb: (message: T | END) => void): void
   flush(cb: (items: T[] | END) => void): void
   close(): void
@@ -321,14 +321,14 @@ export interface PredicateTakeableChannel<T> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
 }
 
-export interface MulticastChannel<T> {
+export interface MulticastChannel<T extends NotUndefined> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
   put(message: T | END): void
   close(): void
 }
 
-export function multicastChannel<T>(): MulticastChannel<T>
-export function stdChannel<T>(): MulticastChannel<T>
+export function multicastChannel<T extends NotUndefined>(): MulticastChannel<T>
+export function stdChannel<T extends NotUndefined>(): MulticastChannel<T>
 
 export function detach(forkEffect: ForkEffect): ForkEffect
 

--- a/packages/core/types/ts3.6/channels.test.ts
+++ b/packages/core/types/ts3.6/channels.test.ts
@@ -59,6 +59,24 @@ function testChannel() {
   c1.flush((messages: Array<{foo: string}> | END) => {});
 
   c1.close();
+
+  // Testing that we can't define channels that pass void or undefined
+  // $ExpectError
+  const voidChannel: Channel<void> = channel();
+  // $ExpectError
+  const voidChannel2 = channel<void>();
+  // $ExpectError
+  const undefinedChannel = channel<undefined>();
+  // $ExpectError
+  channel().put();
+  // $ExpectError
+  channel().put(undefined);
+
+  // Testing that we can pass primitives into channels
+  channel().put(null);
+  channel().put(42);
+  channel().put('test');
+  channel().put(true);
 }
 
 function testEventChannel(secs: number) {
@@ -100,11 +118,32 @@ function testEventChannel(secs: number) {
   c1.flush((messages: number[] | END) => {});
 
   c1.close();
+
+  // $ExpectError
+  const c4: EventChannel<void> = eventChannel(() => () => {})
+
+  // $ExpectError
+  const c5 = eventChannel<void>(emit => {
+    emit()
+    return () => {}
+  })
+
+  const c6 = eventChannel(emit => {
+    // $ExpectError
+    emit()
+    return () => {}
+  })
 }
 
 function testMulticastChannel() {
   const c1: MulticastChannel<{foo: string}> = multicastChannel<{foo: string}>();
   const c2: MulticastChannel<{foo: string}> = stdChannel<{foo: string}>();
+  // $ExpectError
+  const c3: MulticastChannel<void> = stdChannel()
+  // $ExpectError
+  const c4 = multicastChannel<void>()
+  // $ExpectError
+  const c5 = stdChannel<void>()
 
   // $ExpectError
   c1.take();

--- a/packages/core/types/ts3.6/index.d.ts
+++ b/packages/core/types/ts3.6/index.d.ts
@@ -1,5 +1,5 @@
 import { Action, Middleware } from 'redux'
-import { Saga, Buffer, Channel, END as EndType, Predicate, SagaIterator, Task } from '@redux-saga/types'
+import { Saga, Buffer, Channel, END as EndType, Predicate, SagaIterator, Task, NotUndefined } from '@redux-saga/types'
 import { ForkEffect } from './effects'
 
 export { Saga, SagaIterator, Buffer, Channel, Task }
@@ -264,7 +264,7 @@ export interface FlushableChannel<T> {
  * buffering will deliver message using a FIFO strategy: a new taker will be
  * delivered the oldest message in the buffer.
  */
-export function channel<T>(buffer?: Buffer<T>): Channel<T>
+export function channel<T extends NotUndefined>(buffer?: Buffer<T>): Channel<T>
 
 /**
  * Creates channel that will subscribe to an event source using the `subscribe`
@@ -305,12 +305,12 @@ export function channel<T>(buffer?: Buffer<T>): Channel<T>
  * @param buffer optional Buffer object to buffer messages on this channel. If
  *   not provided, messages will not be buffered on this channel.
  */
-export function eventChannel<T>(subscribe: Subscribe<T>, buffer?: Buffer<T>): EventChannel<T>
+export function eventChannel<T extends NotUndefined>(subscribe: Subscribe<T>, buffer?: Buffer<T>): EventChannel<T>
 
 export type Subscribe<T> = (cb: (input: T | END) => void) => Unsubscribe
 export type Unsubscribe = () => void
 
-export interface EventChannel<T> {
+export interface EventChannel<T extends NotUndefined> {
   take(cb: (message: T | END) => void): void
   flush(cb: (items: T[] | END) => void): void
   close(): void
@@ -320,14 +320,14 @@ export interface PredicateTakeableChannel<T> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
 }
 
-export interface MulticastChannel<T> {
+export interface MulticastChannel<T extends NotUndefined> {
   take(cb: (message: T | END) => void, matcher?: Predicate<T>): void
   put(message: T | END): void
   close(): void
 }
 
-export function multicastChannel<T>(): MulticastChannel<T>
-export function stdChannel<T>(): MulticastChannel<T>
+export function multicastChannel<T extends NotUndefined>(): MulticastChannel<T>
+export function stdChannel<T extends NotUndefined>(): MulticastChannel<T>
 
 export function detach(forkEffect: ForkEffect): ForkEffect
 

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -42,6 +42,8 @@ export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends Gua
   ? A
   : P extends StringableActionCreator<infer A> ? A : Action
 
+export type NotUndefined = {} | null
+
 /**
  * Used to implement the buffering strategy for a channel. The Buffer interface
  * defines 3 methods: `isEmpty`, `put` and `take`
@@ -76,7 +78,7 @@ export interface Buffer<T> {
  *
  * The Channel interface defines 3 methods: `take`, `put` and `close`
  */
-export interface Channel<T> {
+export interface Channel<T extends NotUndefined> {
   /**
    * Used to register a taker. The take is resolved using the following rules
    *

--- a/packages/types/types/ts3.6/index.d.ts
+++ b/packages/types/types/ts3.6/index.d.ts
@@ -41,6 +41,8 @@ export type ActionMatchingSubPattern<P extends ActionSubPattern> = P extends Gua
   ? A
   : P extends StringableActionCreator<infer A> ? A : Action
 
+export type NotUndefined = {} | null
+
 /**
  * Used to implement the buffering strategy for a channel. The Buffer interface
  * defines 3 methods: `isEmpty`, `put` and `take`
@@ -75,7 +77,7 @@ export interface Buffer<T> {
  *
  * The Channel interface defines 3 methods: `take`, `put` and `close`
  */
-export interface Channel<T> {
+export interface Channel<T extends NotUndefined> {
   /**
    * Used to register a taker. The take is resolved using the following rules
    *


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            |  |
| Patch: Bug Fix?          |    |
| Major: Breaking Change?  |    |
| Minor: New Feature?      | 👍 |
| Tests Added + Pass?      | Yes |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

I've run into the pitfall a few times recently of making a void-emitting event channel. I decided that it would be great if the types enforced that incompatibility instead of happily accepting the invalid type, hiding the bug until run time.