### PR TITLE
Adds isAborted method and joiners array property to mock task

### DIFF
--- a/.changeset/giant-cherries-tie.md
+++ b/.changeset/giant-cherries-tie.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/testing-utils': patch
+---
+
+Adds missing isAborted method to mock task and deprecates its setRunning method

--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -113,7 +113,9 @@ describe('main', () => {
 });
 ```
 
-You can also use mock task's functions `setRunning`, `setResult` and `setError` to set mock task's state. For example `mockTask.setRunning(false)`.
+You can use a mock task's `setResult`, `setError`, and `cancel` methods to control its state. For example `mockTask.setResult(42)` will set its internal status to Done and any `join` effect given that task will return `42`.
+
+Calling `setResult`, `setError`, or `cancel` on a mock task after having already called one of them, trying to change its status a second time, will throw an error.
 
 ### Note
 

--- a/packages/testing-utils/__tests__/createMockTask.js
+++ b/packages/testing-utils/__tests__/createMockTask.js
@@ -1,7 +1,8 @@
-import { fork, cancel } from 'redux-saga/effects'
+import { runSaga } from '@redux-saga/core'
+import { fork, cancel, join } from 'redux-saga/effects'
 import { createMockTask } from '../src'
 
-test('should allow to use createMockTask for testing purposes', () => {
+test('can be cancelled', () => {
   function* sagaToRun() {}
 
   function* rootSaga() {
@@ -13,4 +14,99 @@ test('should allow to use createMockTask for testing purposes', () => {
   const generator = rootSaga()
   expect(generator.next().value).toEqual(fork(sagaToRun))
   expect(generator.next(taskMock).value).toEqual(cancel(taskMock))
+})
+
+test('can be joined', () => {
+  function* sagaToRun() {}
+
+  function* rootSaga() {
+    const task = yield fork(sagaToRun)
+    yield join(task)
+  }
+
+  const taskMock = createMockTask()
+  const generator = rootSaga()
+  expect(generator.next().value).toEqual(fork(sagaToRun))
+  expect(generator.next(taskMock).value).toEqual(join(taskMock))
+})
+
+test('returns a value from being joined when result is set', done => {
+  runSaga({}, function* saga() {
+    const task = createMockTask()
+    task.setResult(42)
+    const result = yield join(task)
+    expect(result).toBe(42)
+    done()
+  })
+})
+
+test('throws an error from being joined when an error is set', done => {
+  runSaga({}, function* saga() {
+    const task = createMockTask()
+    const givenErr = new Error('something wrong')
+    task.setError(givenErr)
+    try {
+      yield join(task)
+    } catch (err) {
+      expect(err).toBe(givenErr)
+      done()
+    }
+  })
+})
+
+test('is running when created', () => {
+  const taskMock = createMockTask()
+  expect(taskMock.isRunning()).toBe(true)
+  expect(taskMock.result()).toBe(undefined)
+  expect(taskMock.error()).toBe(undefined)
+})
+
+test('is not running after setting the result', () => {
+  const taskMock = createMockTask()
+  taskMock.setResult(42)
+  expect(taskMock.isRunning()).toBe(false)
+  expect(taskMock.isAborted()).toBe(false)
+  expect(taskMock.isCancelled()).toBe(false)
+  expect(taskMock.result()).toBe(42)
+})
+
+test('is not running after setting an error', () => {
+  const taskMock = createMockTask()
+  const err = new Error('Oh no')
+  taskMock.setError(err)
+  expect(taskMock.isRunning()).toBe(false)
+  expect(taskMock.isAborted()).toBe(true)
+  expect(taskMock.isCancelled()).toBe(false)
+  expect(taskMock.error()).toBe(err)
+})
+
+test('is not running after cancelling', () => {
+  const taskMock = createMockTask()
+  taskMock.cancel()
+  expect(taskMock.isRunning()).toBe(false)
+  expect(taskMock.isAborted()).toBe(false)
+  expect(taskMock.isCancelled()).toBe(true)
+})
+
+test('throws an error when making invalid state transitions', () => {
+  const cancelledTask = createMockTask()
+  cancelledTask.cancel()
+  const cancelledError = /The task is no longer Running, it is Cancelled/
+  expect(() => cancelledTask.setResult(42)).toThrowError(cancelledError)
+  expect(() => cancelledTask.setError()).toThrowError(cancelledError)
+  expect(() => cancelledTask.cancel()).toThrowError(cancelledError)
+
+  const abortedTask = createMockTask()
+  abortedTask.setError(new Error('Bad things'))
+  const abortedErrorPattern = /The task is no longer Running, it is Aborted/
+  expect(() => abortedTask.setResult(42)).toThrowError(abortedErrorPattern)
+  expect(() => abortedTask.setError()).toThrowError(abortedErrorPattern)
+  expect(() => abortedTask.cancel()).toThrowError(abortedErrorPattern)
+
+  const completedTask = createMockTask()
+  completedTask.setResult(42)
+  const completedErrorPattern = /The task is no longer Running, it is Done/
+  expect(() => completedTask.setResult(42)).toThrowError(completedErrorPattern)
+  expect(() => completedTask.setError()).toThrowError(completedErrorPattern)
+  expect(() => completedTask.cancel()).toThrowError(completedErrorPattern)
 })

--- a/packages/testing-utils/__tests__/createMockTask.js
+++ b/packages/testing-utils/__tests__/createMockTask.js
@@ -30,6 +30,14 @@ test('can be passed to the join effect without an error', () => {
   expect(generator.next(taskMock).value).toEqual(join(taskMock))
 })
 
+test('warns when using deprecated setRunning method', () => {
+  const spy = jest.spyOn(console, 'warn')
+  const task = createMockTask()
+  task.setRunning(false)
+  expect(spy).toHaveBeenCalledWith(expect.stringMatching(/setRunning has been deprecated/))
+  spy.mockRestore()
+})
+
 test('returns a value from being joined when result is set', done => {
   runSaga({}, function* saga() {
     const task = createMockTask()

--- a/packages/testing-utils/src/index.js
+++ b/packages/testing-utils/src/index.js
@@ -20,15 +20,18 @@ export const cloneableGenerator = generatorFunc => (...args) => {
 
 export function createMockTask() {
   let _isRunning = true
+  let _isAborted = false
   let _result
   let _error
 
   return {
     [TASK]: true,
     isRunning: () => _isRunning,
+    isAborted: () => _isAborted,
     result: () => _result,
     error: () => _error,
     cancel: () => {},
+    joiners: [],
 
     setRunning: b => (_isRunning = b),
     setResult: r => (_result = r),

--- a/packages/testing-utils/src/index.js
+++ b/packages/testing-utils/src/index.js
@@ -1,4 +1,5 @@
 import { TASK } from '@redux-saga/symbols'
+import { RUNNING, CANCELLED, ABORTED, DONE } from '@redux-saga/core/src/internal/task-status'
 
 export const cloneableGenerator = generatorFunc => (...args) => {
   const history = []
@@ -19,22 +20,31 @@ export const cloneableGenerator = generatorFunc => (...args) => {
 }
 
 export function createMockTask() {
-  let _isRunning = true
-  let _isAborted = false
-  let _result
-  let _error
+  let status = RUNNING
+  let taskResult
+  let taskError
 
   return {
     [TASK]: true,
-    isRunning: () => _isRunning,
-    isAborted: () => _isAborted,
-    result: () => _result,
-    error: () => _error,
+    isRunning: () => status === RUNNING,
+    isCancelled: () => status === CANCELLED,
+    isAborted: () => status === ABORTED,
+    result: () => taskResult,
+    error: () => taskError,
     cancel: () => {},
     joiners: [],
 
-    setRunning: b => (_isRunning = b),
-    setResult: r => (_result = r),
-    setError: e => (_error = e),
+    setRunning: () => (status = RUNNING),
+    setResult: r => {
+      taskResult = r
+      status = DONE
+    },
+    setError: e => {
+      taskError = e
+      status = ABORTED
+    },
+    setIsAborted: () => {
+      status = ABORTED
+    },
   }
 }

--- a/packages/testing-utils/src/index.js
+++ b/packages/testing-utils/src/index.js
@@ -58,6 +58,18 @@ export function createMockTask() {
     },
     joiners: [],
 
+    /**
+     * @deprecated Use `setResult`, `setError`, or `cancel` to change the
+     * running status of the mock task.
+     */
+    setRunning: () => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'setRunning has been deprecated. It no longer has any effect when being called. ' +
+          'If you were calling setResult or setError followed by setRunning, those methods now change the ' +
+          'running status of the task. Simply remove the call to setRunning for the desired behavior.',
+      )
+    },
     setResult: r => {
       assertStatusRunning(status)
       taskResult = r

--- a/packages/testing-utils/types/index.d.ts
+++ b/packages/testing-utils/types/index.d.ts
@@ -107,7 +107,8 @@ export interface SagaIteratorClone extends SagaIterator {
 export function createMockTask(): MockTask
 
 export interface MockTask extends Task {
-  setRunning(running: boolean): void
+  setRunning(): void
   setResult(result: any): void
   setError(error: any): void
+  setAborted(): void
 }

--- a/packages/testing-utils/types/index.d.ts
+++ b/packages/testing-utils/types/index.d.ts
@@ -107,6 +107,11 @@ export interface SagaIteratorClone extends SagaIterator {
 export function createMockTask(): MockTask
 
 export interface MockTask extends Task {
+  /**
+   * @deprecated Use {@link setResult}, {@link setError}, or {@link cancel} to
+   * change the running status of the mock task.
+   */
+  setRunning(running: boolean): void
   setResult(result: any): void
   setError(error: any): void
 }

--- a/packages/testing-utils/types/index.d.ts
+++ b/packages/testing-utils/types/index.d.ts
@@ -107,8 +107,6 @@ export interface SagaIteratorClone extends SagaIterator {
 export function createMockTask(): MockTask
 
 export interface MockTask extends Task {
-  setRunning(): void
   setResult(result: any): void
   setError(error: any): void
-  setAborted(): void
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                        | A <!--(Can use an emoji 👍) --> |
| ------------------------ | ---  |
| Fixed Issues?            | Fixes #2205 |
| Patch: Bug Fix?          |  👍  |
| Major: Breaking Change?  |    |
| Minor: New Feature?      |    |
| Tests Added + Pass?      | No new tests |
| Any Dependency Changes?  |    |

<!-- Describe your changes below in as much detail as possible -->

When doing saga integration testing (using [`expectSaga` from redux-saga-test-plan](https://redux-saga-test-plan.jeremyfairbank.com/integration-testing/)), creating a mock task (passed into the saga using the [`fork.fn`](https://redux-saga-test-plan.jeremyfairbank.com/integration-testing/mocking/static-providers.html#:~:text=by%20fn.-,fork.fn,-Match%20fork%20by) static providers) that's passed to a real `join` effect throws an error. Adding `isAborted` and the `joiners` array are necessary for it to not throw an error.

During code review, it was determined that `createMockTask` should have an API more similar to the real task implementation. `setRunning` was deprecated, and trying to change the state of a task more than once will now throw an error.

Also includes new unit tests for covering basic usage, and a small updates to the docs with slightly improved instructions.