### PR TITLE
bug: throttle now accepts a channel as originally intended 

### DIFF
--- a/.changeset/neat-wolves-wink.md
+++ b/.changeset/neat-wolves-wink.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/core': patch
+---
+
+throttle now accepts a channel as originally intended

--- a/.changeset/neat-wolves-wink.md
+++ b/.changeset/neat-wolves-wink.md
@@ -1,4 +1,5 @@
 ---
+'redux-saga': patch
 '@redux-saga/core': patch
 ---
 

--- a/packages/core/src/internal/io-helpers.js
+++ b/packages/core/src/internal/io-helpers.js
@@ -39,13 +39,13 @@ export function takeLeading(patternOrChannel, worker, ...args) {
   return fork(takeLeadingHelper, patternOrChannel, worker, ...args)
 }
 
-export function throttle(ms, pattern, worker, ...args) {
+export function throttle(ms, patternOrChannel, worker, ...args) {
   if (process.env.NODE_ENV !== 'production') {
-    check(pattern, is.notUndef, 'throttle requires a pattern')
+    check(patternOrChannel, is.notUndef, `throttle requires a pattern or channel`)
     check(worker, is.notUndef, 'throttle requires a saga parameter')
   }
 
-  return fork(throttleHelper, ms, pattern, worker, ...args)
+  return fork(throttleHelper, ms, patternOrChannel, worker, ...args)
 }
 
 export function retry(maxTries, delayLength, worker, ...args) {


### PR DESCRIPTION
Closes: #1805

This allows a pattern **or** channel to be passed to `throttle`.  It's a feature we've never had before but it's also something that is "supported" in our docs.

| Q                       | A <!--(Can use an emoji 👍) -->                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | #1805  |
| Patch: Bug Fix?         |                                                                        |
| Major: Breaking Change? |                                                                        |
| Minor: New Feature?     | Yes                                                                       |
| Tests Added + Pass?     | Yes                                                                    |
| Any Dependency Changes? |                                                                        |
