### PR TITLE
Update effects.d.ts code docs to reflect puts error bubbling behavior

### DIFF
--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -359,8 +359,8 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
 
 /**
  * Creates an Effect description that instructs the middleware to dispatch an
- * action to the Store. This effect is non-blocking and any errors that are
- * thrown downstream (e.g. in a reducer) will not bubble back into the saga.
+ * action to the Store. This effect is non-blocking, any errors that are
+ * thrown downstream (e.g. in a reducer) will bubble back into the saga.
  *
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */

--- a/packages/core/types/ts3.6/effects.d.ts
+++ b/packages/core/types/ts3.6/effects.d.ts
@@ -378,8 +378,8 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
 
 /**
  * Creates an Effect description that instructs the middleware to dispatch an
- * action to the Store. This effect is non-blocking and any errors that are
- * thrown downstream (e.g. in a reducer) will not bubble back into the saga.
+ * action to the Store. This effect is non-blocking, any errors that are
+ * thrown downstream (e.g. in a reducer) will bubble back into the saga.
  *
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */


### PR DESCRIPTION
The documentation here doesn't match what the real behavior is. (Also inconsistent with the readme docs)

Fixed the code comment on put which stated that errors from a reducer would not bubble back into the saga where as they actually do. 

The code doc is inconsistent with https://redux-saga.js.org/docs/api/#putaction

Code pen to prove behavior https://codesandbox.io/s/redux-saga-example-put-bubbles-error-vmyvvm

Also came across this tests which, as far as I can tell, proves that errors are bubbled
https://github.com/redux-saga/redux-saga/blob/38ac71b0a5bcbf086bd55f77edf6be12a4078e89/packages/core/__tests__/interpreter/put.js#L113
