### PR TITLE
feat: compile `setVerbosity` into package

### DIFF
--- a/packages/simple-saga-monitor/src/index.js
+++ b/packages/simple-saga-monitor/src/index.js
@@ -8,7 +8,11 @@ import Manager from './modules/Manager'
 const globalScope = IS_REACT_NATIVE ? global : IS_BROWSER ? window : null
 
 // `VERBOSE` can be made a setting configured from the outside.
-const VERBOSE = false
+let VERBOSE = false
+
+function setVerbosity(verbosity) {
+  VERBOSE = verbosity
+}
 
 function time() {
   if (typeof performance !== 'undefined' && performance.now) {
@@ -133,6 +137,9 @@ if (globalScope) {
 
 // Export the snapshot-logging function for arbitrary use by external code.
 export { logSaga }
+
+// Export a function to set the verbosity
+export { setVerbosity }
 
 // Export the `sagaMonitor` to pass to the middleware.
 export default {

--- a/packages/simple-saga-monitor/src/index.js
+++ b/packages/simple-saga-monitor/src/index.js
@@ -7,7 +7,7 @@ import Manager from './modules/Manager'
 
 const globalScope = IS_REACT_NATIVE ? global : IS_BROWSER ? window : null
 
-// `VERBOSE` can be made a setting configured from the outside.
+// `VERBOSE` can be configured from the outside using `setVerbosity`
 let VERBOSE = false
 
 function setVerbosity(verbosity) {


### PR DESCRIPTION
Right now, `VERBOSITY` is compiled away, as it's not used and is constantly false. This allows developers to quickly read the verbose effects generated by their sagas