### PR TITLE
fix(docs): typo in configureStore function

### DIFF
--- a/docs/introduction/GettingStarted.md
+++ b/docs/introduction/GettingStarted.md
@@ -88,10 +88,10 @@ import mySaga from './sagas'
 // create the saga middleware
 const sagaMiddleware = createSagaMiddleware()
 // mount it on the Store
-const store = configureStore(
+const store = configureStore({
   reducer, 
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(sagaMiddleware),
-)
+})
 
 // then run the saga
 sagaMiddleware.run(mySaga)


### PR DESCRIPTION
Regarding the @redux/toolkit document, an object will be passed to the configureStore function. The current code in line 91 won't work and throws a typescript error.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/main/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                       | A <!--(Can use an emoji 👍) -->                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues --> |
| Patch: Bug Fix?         |                                                                        |
| Major: Breaking Change? |                                                                        |
| Minor: New Feature?     |                                                                        |
| Tests Added + Pass?     | Yes                                                                    |
| Any Dependency Changes? |                                                                        |

<!-- Describe your changes below in as much detail as possible -->
