### PR TITLE
Add leading and trailing options for debounce helper #2380

### DIFF
--- a/.changeset/lazy-suits-wink.md
+++ b/.changeset/lazy-suits-wink.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/core': minor
+---
+
+Added `leading` and `trailing` options to `debounce` helper.

--- a/docs/API.md
+++ b/docs/API.md
@@ -759,11 +759,17 @@ const throttle = (ms, pattern, task, ...args) => fork(function*() {
 ### `throttle(ms, channel, saga, ...args)`
 You can also handle a channel as argument and the behaviour is the same as [`throttle(ms, pattern, saga, ..args)`](#throttlems-pattern-saga-args)
 
-### `debounce(ms, pattern, saga, ...args)`
+### `debounce(delayLengthOrOptions, pattern, saga, ...args)`
 
-Spawns a `saga` on an action dispatched to the Store that matches `pattern`. Saga will be called after it stops taking `pattern` actions for `ms` milliseconds. Purpose of this is to prevent calling saga until the actions are settled off.
+Spawns a `saga` on an action dispatched to the Store that matches `pattern`. The saga will be called after it stops taking `pattern` actions for the specified delay length. The purpose of this is to prevent calling saga until the actions are settled off.
 
-- `ms: Number` - defines how many milliseconds should elapse since the last time `pattern` action was fired to call the `saga`
+- `delayLengthOrOptions: Object | Number`
+
+  - When passing an object, the properties are:
+    - `delayLength: Number` (required) - defines how many milliseconds should elapse since the last time `pattern` action was fired to call the `saga`.
+    - `leading: Boolean` - determines whether to spawn the debounced saga immediately when the first action is dispatched. Defaults to `false`.
+    - `trailing: Boolean` - determines whether to spawn the debounced saga one more time after `delayLength` milliseconds have elapsed (but only if it has been called one or more times in that duration). Defaults to `true`.
+  - Alternatively, the first parameter can be a Number representing the `delayLength`. In this case the other options default to `leading: false` and `trailing: true`.
 
 - `pattern: String | Array | Function` - for more information see docs for [`take(pattern)`](#takepattern)
 

--- a/packages/core/__tests__/sagaHelpers/debounce.js
+++ b/packages/core/__tests__/sagaHelpers/debounce.js
@@ -121,6 +121,151 @@ test('debounce: async actions', () => {
       expect(actual).toEqual(expected)
     })
 })
+test('debounce: leading: true, trailing: true', () => {
+  let called = 0
+  const delayMs = 30
+  const smallDelayMs = delayMs - 10
+  const largeDelayMs = delayMs + 10
+  const actual = []
+  const expected = [
+    [1, 'a'],
+    [2, 'c'],
+    [3, 'd'],
+    [4, 'e'],
+  ]
+  const middleware = sagaMiddleware()
+  const store = createStore(() => ({}), {}, applyMiddleware(middleware))
+  middleware.run(saga)
+
+  function* saga() {
+    const task = yield debounce({ delayLength: delayMs, leading: true, trailing: true }, 'ACTION', fnToCall)
+    yield take('CANCEL_WATCHER')
+    yield cancel(task)
+  }
+
+  function* fnToCall(action) {
+    called++
+    actual.push([called, action.payload])
+  }
+
+  return Promise.resolve()
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'a',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'b',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'c',
+      }),
+    )
+    .then(() => delayP(largeDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'd',
+      }),
+    )
+    .then(() => delayP(largeDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'e',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'CANCEL_WATCHER',
+      }),
+    )
+    .then(() => {
+      // should debounce async actions and pass the lastest action to a worker
+      expect(actual).toEqual(expected)
+    })
+})
+test('debounce: leading: true, trailing: false', () => {
+  let called = 0
+  const delayMs = 30
+  const smallDelayMs = delayMs - 10
+  const largeDelayMs = delayMs + 10
+  const actual = []
+  const expected = [
+    [1, 'a'],
+    [2, 'd'],
+    [3, 'e'],
+  ]
+  const middleware = sagaMiddleware()
+  const store = createStore(() => ({}), {}, applyMiddleware(middleware))
+  middleware.run(saga)
+
+  function* saga() {
+    const task = yield debounce({ delayLength: delayMs, leading: true, trailing: false }, 'ACTION', fnToCall)
+    yield take('CANCEL_WATCHER')
+    yield cancel(task)
+  }
+
+  function* fnToCall(action) {
+    called++
+    actual.push([called, action.payload])
+  }
+
+  return Promise.resolve()
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'a',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'b',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'c',
+      }),
+    )
+    .then(() => delayP(largeDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'd',
+      }),
+    )
+    .then(() => delayP(largeDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'ACTION',
+        payload: 'e',
+      }),
+    )
+    .then(() => delayP(smallDelayMs))
+    .then(() =>
+      store.dispatch({
+        type: 'CANCEL_WATCHER',
+      }),
+    )
+    .then(() => {
+      // should debounce async actions and pass the lastest action to a worker
+      expect(actual).toEqual(expected)
+    })
+})
 test('debounce: cancelled', () => {
   let called = 0
   const delayMs = 30

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -1117,9 +1117,15 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
 export interface DebounceOptions {
   /** Defines how many milliseconds should elapse since the last time `pattern` action was fired to call the `saga`. */
   delayLength: number
-  /** Determines whether to spawn the debounced saga immediately when the first action is dispatched. Defaults to `false`. */
+  /**
+   * Determines whether to spawn the debounced saga immediately when the first action is dispatched.
+   * @default false
+   */
   leading?: boolean
-  /** Determines whether to spawn the debounced saga one more time after `delayLength` milliseconds have elapsed (but only if it has been called one or more times in that duration). Defaults to `true`. */
+  /**
+   * Determines whether to spawn the debounced saga one more time after `delayLength` milliseconds have elapsed (but only if it has been called one or more times in that duration).
+   * @default true
+   */
   trailing?: boolean
 }
 

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -1114,10 +1114,19 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
   ...args: HelperWorkerParameters<T, Fn>
 ): ForkEffect
 
+export interface DebounceOptions {
+  /** Defines how many milliseconds should elapse since the last time `pattern` action was fired to call the `saga`. */
+  delayLength: number
+  /** Determines whether to spawn the debounced saga immediately when the first action is dispatched. Defaults to `false`. */
+  leading?: boolean
+  /** Determines whether to spawn the debounced saga one more time after `delayLength` milliseconds have elapsed (but only if it has been called one or more times in that duration). Defaults to `true`. */
+  trailing?: boolean
+}
+
 /**
  * Spawns a `saga` on an action dispatched to the Store that matches `pattern`.
- * Saga will be called after it stops taking `pattern` actions for `ms`
- * milliseconds. Purpose of this is to prevent calling saga until the actions
+ * Saga will be called after it stops taking `pattern` actions for the specified
+ * delay length. The purpose of this is to prevent calling saga until the actions
  * are settled off.
  *
  * #### Example
@@ -1140,7 +1149,7 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
  * #### Notes
  *
  * `debounce` is a high-level API built using `take`, `delay` and `fork`. Here
- * is how the helper could be implemented using the low-level Effects
+ * is how a simplified version of the helper could be implemented using the low-level Effects
  *
  *    const debounce = (ms, pattern, task, ...args) => fork(function*() {
  *      while (true) {
@@ -1162,8 +1171,9 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
  *      }
  *    })
  *
- * @param ms defines how many milliseconds should elapse since the last time
- *   `pattern` action was fired to call the `saga`
+ * @param delayLengthOrOptions defines how many milliseconds should elapse since the last time
+ *   `pattern` action was fired to call the `saga`. When `DebounceOptions` is passed, may also
+ *   configure whether the saga is called in the `leading` and `trailing` phases of the delay period.
  * @param pattern for more information see docs for `take(pattern)`
  * @param saga a Generator function
  * @param args arguments to be passed to the started task. `debounce` will add
@@ -1171,23 +1181,23 @@ export function throttle<T, Fn extends (...args: any[]) => any>(
  *   argument provided to `saga`)
  */
 export function debounce<P extends ActionPattern>(
-  ms: number,
+  delayLengthOrOptions: number | DebounceOptions,
   pattern: P,
   worker: (action: ActionMatchingPattern<P>) => any,
 ): ForkEffect
 export function debounce<P extends ActionPattern, Fn extends (...args: any[]) => any>(
-  ms: number,
+  delayLengthOrOptions: number | DebounceOptions,
   pattern: P,
   worker: Fn,
   ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
 ): ForkEffect
 export function debounce<A extends Action>(
-  ms: number,
+  delayLengthOrOptions: number | DebounceOptions,
   pattern: ActionPattern<A>,
   worker: (action: A) => any,
 ): ForkEffect
 export function debounce<A extends Action, Fn extends (...args: any[]) => any>(
-  ms: number,
+  delayLengthOrOptions: number | DebounceOptions,
   pattern: ActionPattern<A>,
   worker: Fn,
   ...args: HelperWorkerParameters<A, Fn>


### PR DESCRIPTION
| Q                       | A <!--(Can use an emoji 👍) -->                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | Fixes #2380|
| Patch: Bug Fix?         |                     No                                                   |
| Major: Breaking Change? |        No                                                                 |
| Minor: New Feature?     |    Yes                                                                   |
| Tests Added + Pass?     | Yes                                                                    |
| Any Dependency Changes? |   No                                                                     |

This adds `leading` and `trailing` options to the `debounce` helper, as suggested in the linked issue. The first parameter to `debounce` can now be an options object of format `{ delayLength: number; leading?: boolean; trailing?: boolean }`, or for backwards compatibility can still just be a `number` specifying `delayLength`.

`leading` defaults to `false` and `trailing` defaults to `true`. The behaviour in this case should be unchanged compared to on `main`.

The behaviour of "leading" and "trailing" should essentially match how it works in [lodash](https://lodash.com/docs/4.17.15#debounce).
