### PR TITLE
#2385: fixed put/putResolve typings for thunk actions

### DIFF
--- a/.changeset/hot-trainers-fry.md
+++ b/.changeset/hot-trainers-fry.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/core': patch
+---
+
+Fixes `put`/`putResolve` typings to support thunk actions

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -357,6 +357,20 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
   ? AllButLast<Parameters<Fn>>
   : Parameters<Fn>
 
+interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action> {
+  <ReturnType>(thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>): ReturnType
+  <Action extends BasicAction>(action: Action): Action
+  <ReturnType, Action extends BasicAction>(
+    action: Action | ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+  ): Action | ReturnType
+}
+
+type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
+  dispatch: ThunkDispatch<State, ExtraThunkArg, BasicAction>,
+  getState: () => State,
+  extraArgument: ExtraThunkArg,
+) => ReturnType
+
 /**
  * Creates an Effect description that instructs the middleware to dispatch an
  * action to the Store. This effect is non-blocking, any errors that are
@@ -365,6 +379,9 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<A extends Action>(action: A): PutEffect<A>
+export function put<ReturnType = any, State = any, ExtraThunkArg = any, BasicAction extends Action = Action>(
+  action: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+): PutEffect<BasicAction>
 
 /**
  * Just like `put` but the effect is blocking (if promise is returned from
@@ -374,6 +391,9 @@ export function put<A extends Action>(action: A): PutEffect<A>
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function putResolve<A extends Action>(action: A): PutEffect<A>
+export function putResolve<ReturnType = any, State = any, ExtraThunkArg = any, BasicAction extends Action = Action>(
+  action: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+): PutEffect<BasicAction>
 
 export type PutEffect<A extends Action = AnyAction> = SimpleEffect<'PUT', PutEffectDescriptor<A>>
 

--- a/packages/core/types/effects.d.ts
+++ b/packages/core/types/effects.d.ts
@@ -365,7 +365,7 @@ interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action> {
   ): Action | ReturnType
 }
 
-type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
+export type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
   dispatch: ThunkDispatch<State, ExtraThunkArg, BasicAction>,
   getState: () => State,
   extraArgument: ExtraThunkArg,

--- a/packages/core/types/effects.test.ts
+++ b/packages/core/types/effects.test.ts
@@ -29,6 +29,7 @@ import {
 } from 'redux-saga/effects'
 import { Action, ActionCreator } from 'redux'
 import { StringableActionCreator, ActionMatchingPattern } from '@redux-saga/types'
+import { ThunkAction } from '@redux-saga/core/effects'
 
 interface MyAction extends Action {
   customField: string
@@ -92,7 +93,15 @@ function* testTake(): SagaIterator {
 }
 
 function* testPut(): SagaIterator {
+  type TestThunkAction = ThunkAction<number, object, object, { type: 'thunk-action' }>
+  const thunkActionCreator = (): TestThunkAction => (dispatch) => {
+    dispatch({ type: 'thunk-action' })
+
+    return 42
+  }
+
   yield put({ type: 'my-action' })
+  yield put(thunkActionCreator())
 
   // $ExpectError
   yield put(channel, { type: 'my-action' })
@@ -109,6 +118,7 @@ function* testPut(): SagaIterator {
   yield put(multicastChannel, END)
 
   yield putResolve({ type: 'my-action' })
+  yield putResolve(thunkActionCreator())
 }
 
 function* testCall(): SagaIterator {

--- a/packages/core/types/ts3.6/effects.d.ts
+++ b/packages/core/types/ts3.6/effects.d.ts
@@ -376,6 +376,20 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
   ? AllButLast<Parameters<Fn>>
   : Parameters<Fn>
 
+interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action> {
+  <ReturnType>(thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>): ReturnType
+  <Action extends BasicAction>(action: Action): Action
+  <ReturnType, Action extends BasicAction>(
+    action: Action | ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+  ): Action | ReturnType
+}
+
+type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
+  dispatch: ThunkDispatch<State, ExtraThunkArg, BasicAction>,
+  getState: () => State,
+  extraArgument: ExtraThunkArg,
+) => ReturnType
+
 /**
  * Creates an Effect description that instructs the middleware to dispatch an
  * action to the Store. This effect is non-blocking, any errors that are
@@ -384,6 +398,9 @@ export type HelperWorkerParameters<T, Fn extends (...args: any[]) => any> = Last
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function put<A extends Action>(action: A): PutEffect<A>
+export function put<ReturnType = any, State = any, ExtraThunkArg = any, BasicAction extends Action = Action>(
+  action: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+): PutEffect<BasicAction>
 
 /**
  * Just like `put` but the effect is blocking (if promise is returned from
@@ -393,6 +410,9 @@ export function put<A extends Action>(action: A): PutEffect<A>
  * @param action [see Redux `dispatch` documentation for complete info](https://redux.js.org/api/store#dispatchaction)
  */
 export function putResolve<A extends Action>(action: A): PutEffect<A>
+export function putResolve<ReturnType = any, State = any, ExtraThunkArg = any, BasicAction extends Action = Action>(
+  action: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>,
+): PutEffect<BasicAction>
 
 export type PutEffect<A extends Action = AnyAction> = SimpleEffect<'PUT', PutEffectDescriptor<A>>
 

--- a/packages/core/types/ts3.6/effects.d.ts
+++ b/packages/core/types/ts3.6/effects.d.ts
@@ -384,7 +384,7 @@ interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action> {
   ): Action | ReturnType
 }
 
-type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
+export type ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction extends Action> = (
   dispatch: ThunkDispatch<State, ExtraThunkArg, BasicAction>,
   getState: () => State,
   extraArgument: ExtraThunkArg,


### PR DESCRIPTION
Closes #2385 

Fixes type checks for `put` and `putResolve` with thunk actions

| Q                       | A <!--(Can use an emoji 👍) -->                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | #2385 |
| Patch: Bug Fix?         | Yes                                                                        |
| Major: Breaking Change? | No                                     |
| Minor: New Feature?     | No                                   |
| Tests Added + Pass?     | No                                                                    |
| Any Dependency Changes? | No                                                                        |

<!-- Describe your changes below in as much detail as possible -->
