### PR TITLE
Draft: 1250 safe effect

### DIFF
--- a/packages/core/__tests__/sagaHelpers/safeEffect.js
+++ b/packages/core/__tests__/sagaHelpers/safeEffect.js
@@ -1,0 +1,151 @@
+import createSafeEffect, {
+  loadingActionPrefix,
+  errorActionPrefix,
+} from '../../src/internal/sagaHelpers/createSafeEffect'
+import sagaMiddleware from '../../src'
+import { applyMiddleware, createStore } from 'redux'
+import takeSafe from '../../src/internal/sagaHelpers/takeSafe'
+
+// not implemented yet
+const sagaMiddlewareSafe = sagaMiddleware
+
+const testActionType = 'TEST_ACTION'
+const testErrorMessage = 'test error'
+
+const testActionCreator = () => ({
+  type: testActionType,
+  payload: 'test',
+})
+
+testActionCreator.type = testActionType
+
+const makeTestStore = (root, safeEffect) => {
+  const actualActionsThatGotDispatched = []
+  const rootReducer = (state, action) => {
+    actualActionsThatGotDispatched.push(action)
+    return state
+  }
+  const middleware = sagaMiddlewareSafe(safeEffect)
+  const store = applyMiddleware(middleware)(createStore)(rootReducer)
+  middleware.run(root)
+
+  store.getActionHistory = () => actualActionsThatGotDispatched
+
+  return store
+}
+
+test('safeEffect yields loading actions to a store on success', () => {
+  function* root() {
+    yield takeSafe(testActionCreator.type, worker)
+  }
+
+  let workerCalledTimes = 0
+
+  function* worker() {
+    workerCalledTimes++
+  }
+
+  const store = makeTestStore(root)
+
+  store.dispatch(testActionCreator())
+  const [, loadingStartsAction, actualAction, loadingEndedAction] = store.getActionHistory()
+
+  expect(loadingStartsAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
+  expect(loadingStartsAction.payload).toEqual(true)
+
+  expect(actualAction.type).toEqual(testActionCreator.type)
+  expect(actualAction.payload).toEqual(testActionCreator.payload)
+
+  expect(loadingEndedAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
+  expect(loadingEndedAction.payload).toEqual(false)
+
+  expect(workerCalledTimes).toEqual(1)
+})
+
+test('safeEffect yields loading and error actions to a store on error', () => {
+  function* root() {
+    yield takeSafe(testActionCreator.type, worker)
+  }
+
+  let workerCalledTimes = 0
+
+  function* worker() {
+    workerCalledTimes++
+    throw new Error(testErrorMessage)
+  }
+
+  // middleware with the default safe effect wrapper
+  const store = makeTestStore(root)
+
+  store.dispatch(testActionCreator())
+  const [, loadingStartsAction, actualAction, errorAction, loadingEndedAction] = store.getActionHistory()
+
+  expect(loadingStartsAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
+  expect(loadingStartsAction.payload).toEqual(true)
+
+  expect(actualAction.type).toEqual(testActionCreator.type)
+  expect(actualAction.payload).toEqual(testActionCreator.payload)
+
+  expect(errorAction.type).toEqual(`${errorActionPrefix}${testActionCreator.type}`)
+  expect(errorAction.payload.message).toEqual(testErrorMessage)
+
+  expect(loadingEndedAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
+  expect(loadingEndedAction.payload).toEqual(false)
+
+  expect(workerCalledTimes).toEqual(1)
+})
+
+test('safeEffect implements template method, so it can be enhanced with custom behavior on success', () => {
+  let successIsCalled = false
+  const successHandeler = function* () {
+    successIsCalled = true
+  }
+
+  let workerCalledTimes = 0
+
+  function* root() {
+    yield takeSafe(testActionCreator.type, worker)
+  }
+
+  function* worker() {
+    workerCalledTimes++
+  }
+
+  const safeEffect = createSafeEffect(undefined, successHandeler)
+  const store = makeTestStore(root, safeEffect)
+
+  store.dispatch(testActionCreator())
+
+  expect(successIsCalled).toEqual(true)
+  expect(workerCalledTimes).toEqual(1)
+})
+
+test('safeEffect implements template method, so it can be enhanced with custom behavior on failure', () => {
+  let errorIsCalled = false
+  let errorMessageRecieved = ''
+
+  const errorHandeler = function* (action) {
+    errorIsCalled = true
+    errorMessageRecieved = action.payload.message
+  }
+
+  let workerCalledTimes = 0
+
+  function* root() {
+    yield takeSafe(testActionCreator.type, worker)
+  }
+
+  function* worker() {
+    workerCalledTimes++
+    throw new Error(testErrorMessage)
+  }
+
+  const safeEffect = createSafeEffect(undefined, errorHandeler)
+  const store = makeTestStore(root, safeEffect)
+
+  store.dispatch(testActionCreator())
+
+  expect(errorIsCalled).toEqual(true)
+  expect(workerCalledTimes).toEqual(1)
+  expect(errorMessageRecieved).toEqual(testErrorMessage)
+})

--- a/packages/core/__tests__/sagaHelpers/safeEffect.js
+++ b/packages/core/__tests__/sagaHelpers/safeEffect.js
@@ -1,6 +1,7 @@
 import createSafeEffect, {
-  loadingActionPrefix,
-  errorActionPrefix,
+  loadingStartedActionType,
+  loadingCompleteActionType,
+  errorActionType,
 } from '../../src/internal/sagaHelpers/createSafeEffect'
 import sagaMiddleware from '../../src'
 import { applyMiddleware, createStore } from 'redux'
@@ -50,14 +51,14 @@ test('safeEffect yields loading actions to a store on success', () => {
   store.dispatch(testActionCreator())
   const [, loadingStartsAction, actualAction, loadingEndedAction] = store.getActionHistory()
 
-  expect(loadingStartsAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
-  expect(loadingStartsAction.payload).toEqual(true)
+  expect(loadingStartsAction.type).toEqual(loadingStartedActionType)
+  expect(loadingStartsAction.payload).toEqual(testActionCreator.type)
 
   expect(actualAction.type).toEqual(testActionCreator.type)
   expect(actualAction.payload).toEqual(testActionCreator.payload)
 
-  expect(loadingEndedAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
-  expect(loadingEndedAction.payload).toEqual(false)
+  expect(loadingEndedAction.type).toEqual(loadingCompleteActionType)
+  expect(loadingEndedAction.payload).toEqual(testActionCreator.type)
 
   expect(workerCalledTimes).toEqual(1)
 })
@@ -80,17 +81,18 @@ test('safeEffect yields loading and error actions to a store on error', () => {
   store.dispatch(testActionCreator())
   const [, loadingStartsAction, actualAction, errorAction, loadingEndedAction] = store.getActionHistory()
 
-  expect(loadingStartsAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
-  expect(loadingStartsAction.payload).toEqual(true)
+  expect(loadingStartsAction.type).toEqual(loadingStartedActionType)
+  expect(loadingStartsAction.payload).toEqual(testActionCreator.type)
 
   expect(actualAction.type).toEqual(testActionCreator.type)
   expect(actualAction.payload).toEqual(testActionCreator.payload)
 
-  expect(errorAction.type).toEqual(`${errorActionPrefix}${testActionCreator.type}`)
+  expect(errorAction.type).toEqual(errorActionType)
   expect(errorAction.payload.message).toEqual(testErrorMessage)
+  expect(errorAction.actionType).toEqual(testActionCreator.type)
 
-  expect(loadingEndedAction.type).toEqual(`${loadingActionPrefix}${testActionCreator.type}`)
-  expect(loadingEndedAction.payload).toEqual(false)
+  expect(loadingEndedAction.type).toEqual(loadingCompleteActionType)
+  expect(loadingEndedAction.payload).toEqual(testActionCreator.type)
 
   expect(workerCalledTimes).toEqual(1)
 })

--- a/packages/core/src/internal/sagaHelpers/createSafeEffect.js
+++ b/packages/core/src/internal/sagaHelpers/createSafeEffect.js
@@ -1,0 +1,11 @@
+export const loadingActionPrefix = 'loading/'
+export const errorActionPrefix = 'success/'
+
+export default function createSafeEffect(onError, onSuccess) {
+  onError
+  onSuccess
+  return function* (action) {
+    yield action
+    throw new Error('Not implemented')
+  }
+}

--- a/packages/core/src/internal/sagaHelpers/createSafeEffect.js
+++ b/packages/core/src/internal/sagaHelpers/createSafeEffect.js
@@ -1,5 +1,6 @@
-export const loadingActionPrefix = 'loading/'
-export const errorActionPrefix = 'success/'
+export const loadingStartedActionType = 'loading'
+export const loadingCompleteActionType = 'loadingComplete'
+export const errorActionType = 'error'
 
 export default function createSafeEffect(onError, onSuccess) {
   onError

--- a/packages/core/src/internal/sagaHelpers/takeLatest.js
+++ b/packages/core/src/internal/sagaHelpers/takeLatest.js
@@ -1,30 +1,38 @@
 import fsmIterator, { safeName } from './fsmIterator'
 import { cancel, take, fork } from '../io'
+import takeSafe from './takeSafe'
 
-export default function takeLatest(patternOrChannel, worker, ...args) {
-  const yTake = { done: false, value: take(patternOrChannel) }
-  const yFork = (ac) => ({ done: false, value: fork(worker, ...args, ac) })
-  const yCancel = (task) => ({ done: false, value: cancel(task) })
+const takeUnsafe = take
 
-  let task, action
-  const setTask = (t) => (task = t)
-  const setAction = (ac) => (action = ac)
+const takeLatestCreator = (takeEffect = takeUnsafe) => {
+  return (patternOrChannel, worker, ...args) => {
+    const yTake = { done: false, value: takeEffect(patternOrChannel) }
+    const yFork = (ac) => ({ done: false, value: fork(worker, ...args, ac) })
+    const yCancel = (task) => ({ done: false, value: cancel(task) })
 
-  return fsmIterator(
-    {
-      q1() {
-        return { nextState: 'q2', effect: yTake, stateUpdater: setAction }
+    let task, action
+    const setTask = (t) => (task = t)
+    const setAction = (ac) => (action = ac)
+
+    return fsmIterator(
+      {
+        q1() {
+          return { nextState: 'q2', effect: yTake, stateUpdater: setAction }
+        },
+        q2() {
+          return task
+            ? { nextState: 'q3', effect: yCancel(task) }
+            : { nextState: 'q1', effect: yFork(action), stateUpdater: setTask }
+        },
+        q3() {
+          return { nextState: 'q1', effect: yFork(action), stateUpdater: setTask }
+        },
       },
-      q2() {
-        return task
-          ? { nextState: 'q3', effect: yCancel(task) }
-          : { nextState: 'q1', effect: yFork(action), stateUpdater: setTask }
-      },
-      q3() {
-        return { nextState: 'q1', effect: yFork(action), stateUpdater: setTask }
-      },
-    },
-    'q1',
-    `takeLatest(${safeName(patternOrChannel)}, ${worker.name})`,
-  )
+      'q1',
+      `takeLatest(${safeName(patternOrChannel)}, ${worker.name})`,
+    )
+  }
 }
+
+export default takeLatestCreator()
+export const takeLatestSafe = takeLatestCreator(takeSafe)

--- a/packages/core/src/internal/sagaHelpers/takeSafe.js
+++ b/packages/core/src/internal/sagaHelpers/takeSafe.js
@@ -1,0 +1,4 @@
+export default function* takeSafe() {
+  yield 0
+  throw new Error('Not implemented')
+}


### PR DESCRIPTION

| Q                       | A                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | #1250 #1672 #2320 |
| Patch: Bug Fix?         |  No                                                                      |
| Major: Breaking Change? | No                                                                       |
| Minor: New Feature?     | Yes                                                                      |
| Tests Added + Pass?     | Red tests (TDD ready)                             |
| Any Dependency Changes? | No                                                                     |

Closes: #1250 

This **Draft** PR is created in order to discuss possible API change regards adding safe effect ([see the corresponding issue](https://github.com/redux-saga/redux-saga/issues/1250)).

The PR contains red tests on how the feature could work.

**The proposal:**

1. The safe effect is defined once for the whole applications.
2. There're special derivatives created for saga effects and saga helpers with the `safe` suffix that are wrapped in the safe effect under the hood: `takeSafe`, `takeLatestSafe`, `takeLeadingSafe`, `takeEverySafe`.
3. Safe effect could be enhanced with custom behavior by providing additional arguments to the safe effect factory.
4. Safe effect dispatches loading and error actions, so the state could be configured to store the loading and error flags.(the example will be add later)

**Subjects to discuss:**

1. The api itself. The approach and possible edge cases.
2. Are there any additional utilities that should be wrapped in the safe effect?
3. What tests should be add to cover utilities: `takeLatestSafe`, `takeLeadingSafe`, `takeEverySafe` with tests?