### PR TITLE
Avoid saga getting stuck when the callstack overflows

### DIFF
--- a/packages/core/__tests__/interpreter/stackoverflow.js
+++ b/packages/core/__tests__/interpreter/stackoverflow.js
@@ -1,0 +1,38 @@
+import { createStore, applyMiddleware } from 'redux'
+import sagaMiddleware from '../../src'
+import * as io from '../../src/effects'
+
+test('saga escalates a stack overflow to the parent saga', () => {
+  const callAttempts = 1500
+  let actualCallCount = 0
+  let didCatchInWrapper = false
+
+  const rootReducer = () => ({})
+
+  const middleware = sagaMiddleware()
+  createStore(rootReducer, {}, applyMiddleware(middleware))
+
+  function genFnChild() {
+    actualCallCount++
+  }
+
+  function* genFnParent() {
+    for (let i = 0; i < callAttempts; i++) {
+      yield io.call(genFnChild)
+    }
+  }
+
+  function* genWrapper() {
+    try {
+      yield io.call(genFnParent)
+    } catch (exc) {
+      didCatchInWrapper = true
+    }
+  }
+
+  const task = middleware.run(genWrapper)
+  return task.toPromise().then(() => {
+    expect(actualCallCount).toBeLessThan(callAttempts)
+    expect(didCatchInWrapper).toBe(true)
+  })
+})

--- a/packages/core/src/internal/effectRunnerMap.js
+++ b/packages/core/src/internal/effectRunnerMap.js
@@ -122,6 +122,11 @@ function runCallEffect(env, { context, fn, args }, cb, { task }) {
 
     cb(result)
   } catch (error) {
+    // Remove again?
+    if (env._eventStackDepth > 1000) {
+      /* eslint-disable no-console */
+      console.warn('More than 1000 effects are currently processed recursively.')
+    }
     cb(error, true)
   }
 }

--- a/packages/core/src/internal/runSaga.js
+++ b/packages/core/src/internal/runSaga.js
@@ -75,6 +75,7 @@ export function runSaga(
     sagaMonitor,
     onError,
     finalizeRunEffect,
+    _eventStackDepth: 0,
   }
 
   return immediately(() => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/redux-saga/redux-saga/blob/main/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

-->

| Q                       | A <!--(Can use an emoji 👍) -->                                        |
| ----------------------- | ---------------------------------------------------------------------- |
| Fixed Issues?           | contributes to #1592 |
| Patch: Bug Fix?         |  Yes                                                                      |
| Major: Breaking Change? |  No                                                                      |
| Minor: New Feature?     | No                                                                       |
| Tests Added + Pass?     | Yes                                                                    |
| Any Dependency Changes? |  No                                                                      |

<!-- Describe your changes below in as much detail as possible -->

## Problem

As described in #1592 (which was opened ~6.5 years ago), repeated CALL effects can lead to a silently stuck saga state. Here's a short example for a saga that would get stuck silently:

```js
function* sagaThatWillGetStuck() {
  for (let i = 0; i < 1500; i++) {
    yield io.call(someOtherSaga)
  }
}
```

The problem is that repeated CALL effects are processed in a recursive manner which can lead to an overflow of the call stack. Fixing this properly would likely require switching from recursion to iteration for the effect processing (as proposed [here](https://github.com/redux-saga/redux-saga/issues/1592#issuecomment-419857204)), but attempts to do so haven't been successful yet (and weren't prioritized probably).

## Impact

In my opinion, the bug described in #1592 is quite significant. As a library user, running into this bug can happen easily and finding it is very hard since there is no actual error reported. I use redux-saga quite heavily and this is the second time this bug has bitten me. Working around the issue is often simple (even though, not ideal), but finding it actually can be very hard.

## Fix

My PR intends to fix the "silent" and "stuck" issue when a stack overflow occurs. It does NOT fix that the stack overflow will occur. Still, this is an important step into the right direction in my opinion.

The fix works by throwing an error when an effect that was already settled as successful is tried to be settled again as unsuccessful. I'm not sure whether this impacts other scenarios, too (and whether they might be valid?), but my impression is that this should not happen, anyway. Here's why this scenario is triggered in the stackoverflow case:

- at some point, `runCallEffect` cannot call `fn` because the call stack overflows
- the catch-clause is entered. however, `cb(error, true)` won't succeed either, because the stack will overflow once again
- now, the catch-clauses of the parent invocations will also be triggered. similarily, some of these will also crash due to a stack overflow.
- at some point, the call stack has shrunken a bit so that a catch-clause in `runCallEffect` can successfully call `cb(error, true)` for some effect. however, that effect was already settled before by a previous `cb(result)` call.
- since an effect cannot be settled twice, the saga got stuck. therefore, throwing an error in this case "properly" escalates the error.

I hope this makes sense. It's a bit hard to explain, but feel free to step through with a debugger (however, note that some debuggers may crash when the stack overflow is reached).

## Next steps
The current state of the PR is my suggestion for how to mitigate the actual problem a bit. I'm open to suggestions and happy to discuss this. I'm very eager to improve the situation, since I rely heavily on redux-saga and the current state seems a bit brittle, to be honest.