### PR TITLE
Fix docs deploy build on Node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
         run: yarn install --frozen-lockfile --non-interactive
       - name: Build
         run: yarn build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary

- allow the legacy OpenSSL provider for the Docusaurus production build step in the docs deploy workflow
- keep the workaround scoped to the GitHub Pages build job

## Why

The docs site is still on an older Docusaurus/webpack stack that hits disabled OpenSSL hash algorithms under Node 20, causing the GH Pages deploy build to fail before deployment.

## Validation

- `NODE_OPTIONS=--openssl-legacy-provider yarn build` from `website/`