### PR TITLE
[codex] Fix cloneableGenerator history replay

### DIFF
--- a/.changeset/cloneable-generator-history.md
+++ b/.changeset/cloneable-generator-history.md
@@ -1,0 +1,5 @@
+---
+'@redux-saga/testing-utils': patch
+---
+
+Preserve throw and return calls when cloning cloneable generators.

--- a/packages/testing-utils/__tests__/cloneableGenerator.js
+++ b/packages/testing-utils/__tests__/cloneableGenerator.js
@@ -58,3 +58,79 @@ test('it should allow to "clone" the generator', () => {
   })
   expect(() => cloneThrow.throw('throws an exception')).toThrow()
 })
+
+test('it should clone generators after a thrown error is handled', () => {
+  const error = new Error('boom')
+  const genFunc = function* () {
+    try {
+      yield 'start'
+    } catch (err) {
+      const recovery = yield `caught ${err.message}`
+
+      if (recovery) {
+        yield 'recovered'
+      } else {
+        yield 'not recovered'
+      }
+    }
+  }
+
+  const cloneableGen = cloneableGenerator(genFunc)()
+  expect(cloneableGen.next()).toEqual({
+    value: 'start',
+    done: false,
+  })
+  expect(cloneableGen.throw(error)).toEqual({
+    value: 'caught boom',
+    done: false,
+  })
+
+  const clone = cloneableGen.clone()
+
+  expect(cloneableGen.next(true)).toEqual({
+    value: 'recovered',
+    done: false,
+  })
+  expect(clone.next(false)).toEqual({
+    value: 'not recovered',
+    done: false,
+  })
+})
+
+test('it should clone generators after return jumps to a finally block', () => {
+  const genFunc = function* () {
+    try {
+      yield 'start'
+      yield 'unreachable after return'
+    } finally {
+      const shouldCleanup = yield 'cleanup'
+
+      if (shouldCleanup) {
+        yield 'cleaned'
+      } else {
+        yield 'skipped cleanup'
+      }
+    }
+  }
+
+  const cloneableGen = cloneableGenerator(genFunc)()
+  expect(cloneableGen.next()).toEqual({
+    value: 'start',
+    done: false,
+  })
+  expect(cloneableGen.return()).toEqual({
+    value: 'cleanup',
+    done: false,
+  })
+
+  const clone = cloneableGen.clone()
+
+  expect(cloneableGen.next(true)).toEqual({
+    value: 'cleaned',
+    done: false,
+  })
+  expect(clone.next(false)).toEqual({
+    value: 'skipped cleanup',
+    done: false,
+  })
+})

--- a/packages/testing-utils/src/index.js
+++ b/packages/testing-utils/src/index.js
@@ -18,18 +18,20 @@ export const cloneableGenerator =
   (...args) => {
     const history = []
     const gen = generatorFunc(...args)
+    const record = (method, arg) => {
+      history.push({ method, arg })
+      return gen[method](arg)
+    }
+
     return {
-      next: (arg) => {
-        history.push(arg)
-        return gen.next(arg)
-      },
+      next: (arg) => record('next', arg),
       clone: () => {
         const clonedGen = cloneableGenerator(generatorFunc)(...args)
-        history.forEach((arg) => clonedGen.next(arg))
+        history.forEach(({ method, arg }) => clonedGen[method](arg))
         return clonedGen
       },
-      return: (value) => gen.return(value),
-      throw: (exception) => gen.throw(exception),
+      return: (value) => record('return', value),
+      throw: (exception) => record('throw', exception),
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #2005.

`cloneableGenerator` now records the generator method used for each history entry, so cloned generators replay `.next(...)`, `.throw(...)`, and `.return(...)` calls in order instead of replaying every historical step as `.next(...)`.

This preserves cloned generator state after handled exceptions and after cancellation-style `.return(...)` jumps into `finally` blocks.

## Changes

- Store clone history as `{ method, arg }` entries.
- Replay the recorded generator method when cloning.
- Add regression tests for cloning after handled `.throw(...)` and `.return(...)` into `finally`.
- Add a patch changeset for `@redux-saga/testing-utils`.

## Validation

- `PATH="/Users/yelouafi/.nvm/versions/node/v20.18.0/bin:$PATH" yarn build`
- `PATH="/Users/yelouafi/.nvm/versions/node/v20.18.0/bin:$PATH" yarn test`
- `yarn prettier --check packages/testing-utils/src/index.js packages/testing-utils/__tests__/cloneableGenerator.js .changeset/cloneable-generator-history.md`
- `yarn eslint packages/testing-utils/src/index.js packages/testing-utils/__tests__/cloneableGenerator.js`

Known unrelated baseline checks:

- `yarn lint` currently fails on unchanged `packages/simple-saga-monitor/src/index.js` because ESLint does not know `globalThis`.
- `yarn --cwd packages/testing-utils test:types` currently fails before checking this change because existing `types/tsconfig.json` uses `Node16` module options that old dtslint TypeScript versions reject.
