### PR TITLE
Fix Saga yield star typing

### DIFF
--- a/.changeset/saga-yield-star-typing.md
+++ b/.changeset/saga-yield-star-typing.md
@@ -1,0 +1,6 @@
+---
+'@redux-saga/core': patch
+'@redux-saga/types': patch
+---
+
+Allow sagas typed with the public `Saga` alias to be composed with `yield*`, and remove stale legacy TypeScript metadata from the effects subpath.

--- a/packages/core/effects/package.json
+++ b/packages/core/effects/package.json
@@ -3,17 +3,5 @@
   "private": true,
   "main": "dist/redux-saga-core-effects.cjs.js",
   "module": "dist/redux-saga-core-effects.esm.js",
-  "types": "../types/effects.d.ts",
-  "typesVersions": {
-    "<3.6": {
-      "*": [
-        "../types/pre-ts3.6/*"
-      ]
-    },
-    "<4.2": {
-      "*": [
-        "../types/pre-ts4.2/*"
-      ]
-    }
-  }
+  "types": "../types/effects.d.ts"
 }

--- a/packages/core/types/effects.test.ts
+++ b/packages/core/types/effects.test.ts
@@ -1,4 +1,4 @@
-import { SagaIterator, Channel, EventChannel, MulticastChannel, Task, Buffer, END, buffers, detach } from 'redux-saga'
+import { Saga, SagaIterator, Channel, EventChannel, MulticastChannel, Task, Buffer, END, buffers, detach } from 'redux-saga'
 import {
   take,
   takeMaybe,
@@ -59,6 +59,14 @@ function* testYieldStarSagaIterator(): SagaIterator {
 
 function* testYieldStarRootSaga(): SagaIterator {
   yield* testYieldStarSagaIterator()
+}
+
+const testYieldStarSaga: Saga = function* () {
+  yield put({ type: 'my-action' })
+}
+
+function* testYieldStarSagaRootSaga(): SagaIterator {
+  yield* testYieldStarSaga()
 }
 
 function* testTake(): SagaIterator {

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -2,7 +2,7 @@ export interface Action<T extends string = string> {
   type: T
 }
 
-export type Saga<Args extends any[] = any[]> = (...args: Args) => Iterator<any>
+export type Saga<Args extends any[] = any[]> = (...args: Args) => Generator<any, any, any>
 
 /**
  * Annotate return type of generators with `SagaIterator` to get strict


### PR DESCRIPTION
## Summary

- Change the public `Saga` alias to return a `Generator`, matching `SagaIterator` so sagas typed as `Saga` can be composed with `yield*`.
- Add type coverage for `yield*` through the `Saga` alias.
- Remove stale `typesVersions` metadata from the `@redux-saga/core/effects` package entry now that the legacy `pre-ts*` declaration folders are gone.
- Add a patch changeset for `@redux-saga/core` and `@redux-saga/types`.

Fixes #2079.

## Validation

- `pnpm run test:types`
