### PR TITLE
Fix Changesets pnpm lockfile generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
         id: changesets
         # https://github.com/changesets/action
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        with:
+          version: pnpm run version-packages
 
   publish:
     name: Publish

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "async": "pnpm --dir examples/async run start",
     "real-world": "pnpm --dir examples/real-world run start",
     "changeset": "changeset",
+    "version-packages": "changeset version && pnpm install --lockfile-only",
     "prerelease": "pnpm run build",
     "release": "changeset publish",
     "postinstall": "preconstruct dev",


### PR DESCRIPTION
## Summary

- add a custom Changesets version command that refreshes `pnpm-lock.yaml` after updating package versions
- configure `changesets/action` to use that command when creating or updating the release PR

## Root cause

After `changeset version` updated internal workspace dependency ranges, the generated package manifests no longer matched `pnpm-lock.yaml`. The Changesets action then attempted to commit those files, which invoked the Husky pre-commit hook. `pnpm exec lint-staged` performed pnpm's dependency-status check and failed its implicit frozen install with `ERR_PNPM_OUTDATED_LOCKFILE`.

Refreshing the lockfile inside the version command ensures it is consistent before the action stages and commits the generated release files.

## Impact

The Version workflow can create or update `changeset-release/main` after package versions and internal dependency ranges change.

## Validation

- `pnpm exec prettier --check package.json .github/workflows/publish.yml`
- parsed `.github/workflows/publish.yml` as YAML
- ran `pnpm run version-packages` in an isolated copy containing the pending changeset
- verified all generated internal ranges were written to `pnpm-lock.yaml`
- ran `pnpm install --frozen-lockfile --offline` successfully after versioning
- repository Husky pre-commit hook passed when creating the fix commit
