### PR TITLE
Deploy docs with GitHub Pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
-      pages: read
+      contents: read # to check out the documentation source
+      pages: read # to read the Pages site configuration
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      pages: write
-      id-token: write
+      pages: write # to deploy the site to GitHub Pages
+      id-token: write # to authenticate the Pages deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,4 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy docs website to GH Pages
+name: Deploy docs website to GitHub Pages
 
 on:
   push:
@@ -15,16 +14,17 @@ defaults:
 permissions: {}
 
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy documentation
+  build:
+    name: Build documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write # to publish the built website to the gh-pages branch
+      contents: read
+      pages: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -36,21 +36,29 @@ jobs:
         with:
           cache: 'false'
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Build
         run: pnpm run build
-        # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      # Keep branch-based publishing in this migration; evaluate GitHub's
-      # artifact-based Pages actions in a follow-up hardening PR.
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./website/build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: ./website/build
+
+  deploy:
+    name: Deploy documentation
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- build the documentation and upload it as a GitHub Pages artifact
- deploy the artifact with GitHub's official Pages action
- replace `peaceiris/actions-gh-pages` and remove repository contents write access
- split building and deployment into least-privilege jobs
- pin the Pages actions to immutable commit SHAs

## Why

The current workflow commits generated files to the `gh-pages` branch through a third-party action. Deploying a Pages artifact directly avoids generated deployment commits, removes the third-party publishing action, and no longer requires the workflow to modify repository contents.

## Validation

- `pnpm --dir website run build`
- YAML syntax validation
- `pnpm exec prettier --check .github/workflows/docs.yml`
- `git diff --check`

## Deployment note

Before merging, change **Settings → Pages → Build and deployment → Source** to **GitHub Actions**. After the first successful artifact-based deployment, the old `gh-pages` branch can be removed separately.
